### PR TITLE
feat: 경기 결과 및 이달의 선수 템플릿 추가

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,10 +4,14 @@ import { useState, useEffect } from 'react';
 import MatchAnnouncementTemplate from '@/components/templates/MatchAnnouncementTemplate';
 import StartingXiATemplate from '@/components/templates/StartingXiATemplate';
 import StartingXiBTemplate from '@/components/templates/StartingXiBTemplate';
+import MatchResultOfficialTemplate from '@/components/templates/MatchResultOfficialTemplate';
+import MatchResultFriendlyTemplate from '@/components/templates/MatchResultFriendlyTemplate';
+import PlayerOfMatchTemplate from '@/components/templates/PlayerOfMatchTemplate';
+import PlayerOfMatchV2Template from '@/components/templates/PlayerOfMatchV2Template';
 import DownloadButton from '@/components/DownloadButton';
 import DatePicker from '@/components/DatePicker';
 import PlayerRowInput from '@/components/PlayerRowInput';
-import { MatchAnnouncementData, StartingXiData, Player, SubPlayer } from '@/types';
+import { MatchAnnouncementData, StartingXiData, Player, SubPlayer, MatchResultOfficialData, MatchResultFriendlyData, PlayerOfMatchData } from '@/types';
 
 // ── 오늘 날짜 helper ─────────────────────────────────────
 function todayStr() {
@@ -64,7 +68,37 @@ const DEFAULT_XI: StartingXiData = {
   substitutes: DEFAULT_SUBS,
 };
 
-type Tab = 'announcement' | 'xi-real' | 'xi-template1';
+const DEFAULT_RESULT_OFFICIAL: MatchResultOfficialData = {
+  badge: '토토배',
+  infoDate: todayStr(),
+  infoVenue: '동국대학교 대운동장',
+  awayTeam: 'FC 정통',
+  homeScore: '2',
+  awayScore: '0',
+  scorers: [
+    { minute: '8', name: '손승현' },
+    { minute: '13', name: '성준서', assist: '위인준' },
+  ],
+  pomName: '공기훈',
+  pomNumber: '7',
+  pomPosition: 'MF',
+};
+
+const DEFAULT_POM: PlayerOfMatchData = {
+  pomName: '공가훈',
+  pomNumber: '10',
+  pomPosition: 'MF',
+  matchLabel: '토토배 · 2026',
+};
+
+const DEFAULT_RESULT_FRIENDLY: MatchResultFriendlyData = {
+  badge: '친선경기',
+  infoDate: todayStr(),
+  infoVenue: '동국대학교 대운동장',
+  awayTeam: '통계학과',
+};
+
+type Tab = 'announcement' | 'xi-real' | 'xi-template1' | 'result-official' | 'result-friendly' | 'pom';
 
 // ── 스타일 상수 ──────────────────────────────────────────
 const inputStyle: React.CSSProperties = {
@@ -109,9 +143,18 @@ export default function Home() {
   const isMobile = windowWidth < 768;
   const PREVIEW_SIZE = isMobile ? Math.min(windowWidth - 24, 480) : 480;
   const scale = PREVIEW_SIZE / CARD_SIZE;
+  // story 모드용 프리뷰 치수 (높이 기준으로 스케일)
+  const STORY_PREVIEW_H = isMobile ? Math.min(windowWidth - 24, 640) : 640;
+  const storyScale = STORY_PREVIEW_H / 1920;
+  const STORY_PREVIEW_W = Math.round(1080 * storyScale);
   const [announcement, setAnnouncement] = useState<MatchAnnouncementData>(DEFAULT_ANNOUNCEMENT);
   const [xiReal, setXiReal] = useState<StartingXiData>(DEFAULT_XI);
   const [xiT1, setXiT1] = useState<StartingXiData>(DEFAULT_XI);
+  const [resultOfficial, setResultOfficial] = useState<MatchResultOfficialData>(DEFAULT_RESULT_OFFICIAL);
+  const [resultFriendly, setResultFriendly] = useState<MatchResultFriendlyData>(DEFAULT_RESULT_FRIENDLY);
+  const [pom, setPom] = useState<PlayerOfMatchData>(DEFAULT_POM);
+  const [pomVersion, setPomVersion] = useState<1 | 2>(1);
+  const pomFormat = pom.format ?? 'square';
 
   // 플레이어 행 업데이트 헬퍼
   const updatePlayer = (
@@ -142,11 +185,18 @@ export default function Home() {
   };
 
   const downloadFilename =
-    tab === 'announcement'
-      ? `runtime-match-announcement`
-      : tab === 'xi-real'
-      ? `runtime-starting-xi`
-      : `runtime-starting-xi-alt`;
+    tab === 'announcement'     ? 'runtime-match-announcement'
+    : tab === 'xi-real'        ? 'runtime-starting-xi'
+    : tab === 'xi-template1'   ? 'runtime-starting-xi-alt'
+    : tab === 'result-official'? 'runtime-match-result-official'
+    : tab === 'result-friendly'? 'runtime-match-result-friendly'
+    :                            'runtime-player-of-the-match';
+
+  const isStoryPreview = tab === 'pom' && pomFormat === 'story';
+  const previewW = isStoryPreview ? STORY_PREVIEW_W : PREVIEW_SIZE;
+  const previewH = isStoryPreview ? STORY_PREVIEW_H : PREVIEW_SIZE;
+  const previewScale = isStoryPreview ? storyScale : scale;
+  const previewCardH = isStoryPreview ? 1920 : CARD_SIZE;
 
   return (
     <div style={{ minHeight: '100vh', background: '#0a0a0a', color: '#fff', position: 'relative' }}>
@@ -159,14 +209,18 @@ export default function Home() {
           left: '-9999px',
           top: '0',
           width: '1080px',
-          height: '1080px',
+          height: tab === 'pom' && pomFormat === 'story' ? '1920px' : '1080px',
           overflow: 'hidden',
           pointerEvents: 'none',
         }}
       >
-        {tab === 'announcement' && <MatchAnnouncementTemplate data={announcement} />}
-        {tab === 'xi-real'      && <StartingXiATemplate data={xiReal} />}
-        {tab === 'xi-template1' && <StartingXiBTemplate data={xiT1} />}
+        {tab === 'announcement'      && <MatchAnnouncementTemplate data={announcement} />}
+        {tab === 'xi-real'           && <StartingXiATemplate data={xiReal} />}
+        {tab === 'xi-template1'      && <StartingXiBTemplate data={xiT1} />}
+        {tab === 'result-official'   && <MatchResultOfficialTemplate data={resultOfficial} />}
+        {tab === 'result-friendly'   && <MatchResultFriendlyTemplate data={resultFriendly} />}
+        {tab === 'pom' && pomVersion === 1 && <PlayerOfMatchTemplate data={pom} />}
+        {tab === 'pom' && pomVersion === 2 && <PlayerOfMatchV2Template data={pom} />}
       </div>
 
       {/* Header */}
@@ -183,9 +237,12 @@ export default function Home() {
           {/* Tab selector */}
           <div style={{ display: 'flex', borderBottom: '1px solid rgba(255,255,255,0.08)' }}>
             {([
-              { key: 'announcement', label: 'MATCH' },
-              { key: 'xi-real',      label: 'XI-A' },
-              { key: 'xi-template1', label: 'XI-B' },
+              { key: 'announcement',    label: 'MATCH' },
+              { key: 'xi-real',         label: 'XI-A' },
+              { key: 'xi-template1',    label: 'XI-B' },
+              { key: 'result-official', label: 'RES-O' },
+              { key: 'result-friendly', label: 'RES-F' },
+              { key: 'pom',            label: 'POM' },
             ] as { key: Tab; label: string }[]).map(({ key, label }) => (
               <button
                 key={key}
@@ -431,6 +488,286 @@ export default function Home() {
               );
             })()}
 
+            {/* ── Match Result Official Form ── */}
+            {tab === 'result-official' && (
+              <>
+                <div style={fieldStyle}>
+                  <label style={labelStyle}>BADGE (대회명)</label>
+                  <input style={inputStyle} value={resultOfficial.badge}
+                    onChange={(e) => setResultOfficial((p) => ({ ...p, badge: e.target.value }))} />
+                </div>
+                <div style={fieldStyle}>
+                  <label style={labelStyle}>INFO DATE</label>
+                  <DatePicker value={resultOfficial.infoDate}
+                    onChange={(v) => setResultOfficial((p) => ({ ...p, infoDate: v }))} />
+                </div>
+                <div style={fieldStyle}>
+                  <label style={labelStyle}>INFO VENUE</label>
+                  <input style={inputStyle} value={resultOfficial.infoVenue}
+                    onChange={(e) => setResultOfficial((p) => ({ ...p, infoVenue: e.target.value }))} />
+                </div>
+                <div style={fieldStyle}>
+                  <label style={labelStyle}>AWAY TEAM</label>
+                  <input style={inputStyle} value={resultOfficial.awayTeam}
+                    onChange={(e) => setResultOfficial((p) => ({ ...p, awayTeam: e.target.value }))} />
+                </div>
+                <div style={fieldStyle}>
+                  <label style={labelStyle}>OPPONENT EMBLEM</label>
+                  <input type="file" accept="image/*"
+                    style={{ ...inputStyle, padding: '6px 12px', cursor: 'pointer' }}
+                    onChange={(e) => {
+                      const file = e.target.files?.[0];
+                      if (!file) return;
+                      const reader = new FileReader();
+                      reader.onload = (ev) => setResultOfficial((p) => ({ ...p, opponentImage: ev.target?.result as string }));
+                      reader.readAsDataURL(file);
+                    }} />
+                </div>
+                <div style={{ display: 'flex', gap: '8px', marginBottom: '12px' }}>
+                  <div style={{ flex: 1 }}>
+                    <label style={labelStyle}>HOME SCORE</label>
+                    <input style={inputStyle} value={resultOfficial.homeScore}
+                      onChange={(e) => setResultOfficial((p) => ({ ...p, homeScore: e.target.value }))} />
+                  </div>
+                  <div style={{ flex: 1 }}>
+                    <label style={labelStyle}>AWAY SCORE</label>
+                    <input style={inputStyle} value={resultOfficial.awayScore}
+                      onChange={(e) => setResultOfficial((p) => ({ ...p, awayScore: e.target.value }))} />
+                  </div>
+                </div>
+
+                <div style={{ borderTop: '1px solid rgba(255,255,255,0.06)', paddingTop: '12px', marginBottom: '8px' }}>
+                  <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: '8px' }}>
+                    <span style={{ fontFamily: "'Bebas Neue', sans-serif", fontSize: '14px', letterSpacing: '3px', color: 'rgba(255,255,255,0.5)' }}>SCORERS</span>
+                    <div style={{ display: 'flex', gap: '6px' }}>
+                      <button type="button" onClick={() => setResultOfficial((p) => ({ ...p, scorers: [...p.scorers, { minute: '', name: '', assist: '' }] }))}
+                        style={{ background: 'transparent', border: '1px solid rgba(204,0,0,0.4)', color: 'rgba(204,0,0,0.7)', fontFamily: "'Bebas Neue', sans-serif", fontSize: '11px', letterSpacing: '2px', padding: '3px 8px', cursor: 'pointer' }}>
+                        + ADD
+                      </button>
+                      <button type="button" onClick={() => setResultOfficial((p) => ({ ...p, scorers: p.scorers.slice(0, -1) }))}
+                        style={{ background: 'transparent', border: '1px solid rgba(255,255,255,0.15)', color: 'rgba(255,255,255,0.3)', fontFamily: "'Bebas Neue', sans-serif", fontSize: '11px', letterSpacing: '2px', padding: '3px 8px', cursor: 'pointer' }}>
+                        - DEL
+                      </button>
+                    </div>
+                  </div>
+                  {resultOfficial.scorers.map((s, i) => (
+                    <div key={i} style={{ display: 'flex', gap: '6px', marginBottom: '6px' }}>
+                      <input style={{ ...inputStyle, width: '52px', flexShrink: 0 }} placeholder="분'" value={s.minute}
+                        onChange={(e) => setResultOfficial((p) => { const sc = [...p.scorers]; sc[i] = { ...sc[i], minute: e.target.value }; return { ...p, scorers: sc }; })} />
+                      <input style={{ ...inputStyle, flex: 1 }} placeholder="득점자" value={s.name}
+                        onChange={(e) => setResultOfficial((p) => { const sc = [...p.scorers]; sc[i] = { ...sc[i], name: e.target.value }; return { ...p, scorers: sc }; })} />
+                      <input style={{ ...inputStyle, flex: 1 }} placeholder="도움 (선택)" value={s.assist ?? ''}
+                        onChange={(e) => setResultOfficial((p) => { const sc = [...p.scorers]; sc[i] = { ...sc[i], assist: e.target.value }; return { ...p, scorers: sc }; })} />
+                    </div>
+                  ))}
+                </div>
+
+                <div style={{ borderTop: '1px solid rgba(255,255,255,0.06)', paddingTop: '12px', marginBottom: '8px' }}>
+                  <span style={{ fontFamily: "'Bebas Neue', sans-serif", fontSize: '14px', letterSpacing: '3px', color: 'rgba(255,255,255,0.5)', display: 'block', marginBottom: '8px' }}>POM</span>
+                  <div style={{ display: 'flex', gap: '8px', marginBottom: '8px' }}>
+                    <div style={{ flex: 1 }}>
+                      <label style={labelStyle}>이름</label>
+                      <input style={inputStyle} value={resultOfficial.pomName}
+                        onChange={(e) => setResultOfficial((p) => ({ ...p, pomName: e.target.value }))} />
+                    </div>
+                    <div style={{ width: '60px', flexShrink: 0 }}>
+                      <label style={labelStyle}>등번호</label>
+                      <input style={inputStyle} value={resultOfficial.pomNumber}
+                        onChange={(e) => setResultOfficial((p) => ({ ...p, pomNumber: e.target.value }))} />
+                    </div>
+                    <div style={{ width: '70px', flexShrink: 0 }}>
+                      <label style={labelStyle}>포지션</label>
+                      <input style={inputStyle} value={resultOfficial.pomPosition}
+                        onChange={(e) => setResultOfficial((p) => ({ ...p, pomPosition: e.target.value }))} />
+                    </div>
+                  </div>
+                  <div style={fieldStyle}>
+                    <label style={labelStyle}>POM 사진</label>
+                    <input type="file" accept="image/*"
+                      style={{ ...inputStyle, padding: '6px 12px', cursor: 'pointer' }}
+                      onChange={(e) => {
+                        const file = e.target.files?.[0];
+                        if (!file) return;
+                        const reader = new FileReader();
+                        reader.onload = (ev) => setResultOfficial((p) => ({ ...p, pomPhoto: ev.target?.result as string }));
+                        reader.readAsDataURL(file);
+                      }} />
+                  </div>
+                </div>
+
+                <div style={fieldStyle}>
+                  <label style={labelStyle}>팀 단체사진</label>
+                  <input type="file" accept="image/*"
+                    style={{ ...inputStyle, padding: '6px 12px', cursor: 'pointer' }}
+                    onChange={(e) => {
+                      const file = e.target.files?.[0];
+                      if (!file) return;
+                      const reader = new FileReader();
+                      reader.onload = (ev) => setResultOfficial((p) => ({ ...p, teamPhoto: ev.target?.result as string }));
+                      reader.readAsDataURL(file);
+                    }} />
+                </div>
+              </>
+            )}
+
+            {/* ── Player Of Match Form ── */}
+            {tab === 'pom' && (
+              <>
+                {/* 버전 스위처 */}
+                <div style={{ display: 'flex', gap: '8px', marginBottom: '20px' }}>
+                  {([1, 2] as const).map((v) => (
+                    <button key={v} onClick={() => setPomVersion(v)} style={{
+                      flex: 1,
+                      padding: '10px',
+                      fontFamily: "'Bebas Neue', sans-serif",
+                      fontSize: '15px',
+                      letterSpacing: '3px',
+                      background: pomVersion === v ? 'rgba(204,0,0,0.18)' : 'rgba(255,255,255,0.04)',
+                      color: pomVersion === v ? '#FF3333' : 'rgba(255,255,255,0.35)',
+                      border: pomVersion === v ? '1px solid rgba(204,0,0,0.5)' : '1px solid rgba(255,255,255,0.08)',
+                      cursor: 'pointer',
+                      borderRadius: '2px',
+                      transition: 'all 0.15s',
+                    }}>
+                      VER. {v}
+                    </button>
+                  ))}
+                </div>
+
+                <div style={fieldStyle}>
+                  <label style={labelStyle}>선수 사진</label>
+                  <input type="file" accept="image/*"
+                    style={{ ...inputStyle, padding: '6px 12px', cursor: 'pointer' }}
+                    onChange={(e) => {
+                      const file = e.target.files?.[0];
+                      if (!file) return;
+                      const reader = new FileReader();
+                      reader.onload = (ev) => setPom((p) => ({ ...p, pomPhoto: ev.target?.result as string }));
+                      reader.readAsDataURL(file);
+                    }} />
+                  {pom.pomPhoto && (
+                    <button
+                      style={{ marginTop: '6px', background: 'transparent', border: '1px solid rgba(204,0,0,0.4)', color: 'rgba(255,255,255,0.5)', fontSize: '12px', fontFamily: "'Bebas Neue', sans-serif", letterSpacing: '2px', padding: '4px 10px', cursor: 'pointer' }}
+                      onClick={() => setPom((p) => ({ ...p, pomPhoto: undefined }))}
+                    >REMOVE IMAGE</button>
+                  )}
+                </div>
+                {pom.pomPhoto && (
+                  <div style={{ marginBottom: '12px', display: 'flex', flexDirection: 'column', gap: '8px' }}>
+                    <div>
+                      <label style={{ ...labelStyle, marginBottom: '6px' }}>
+                        사진 위치 X — {pom.pomPhotoX ?? 50}%
+                      </label>
+                      <input type="range" min={0} max={100} value={pom.pomPhotoX ?? 50}
+                        style={{ width: '100%', accentColor: '#CC0000' }}
+                        onChange={(e) => setPom((p) => ({ ...p, pomPhotoX: Number(e.target.value) }))} />
+                    </div>
+                    <div>
+                      <label style={{ ...labelStyle, marginBottom: '6px' }}>
+                        사진 위치 Y — {pom.pomPhotoY ?? 0}%
+                      </label>
+                      <input type="range" min={0} max={100} value={pom.pomPhotoY ?? 0}
+                        style={{ width: '100%', accentColor: '#CC0000' }}
+                        onChange={(e) => setPom((p) => ({ ...p, pomPhotoY: Number(e.target.value) }))} />
+                    </div>
+                  </div>
+                )}
+                {/* 포맷 선택 */}
+                <div style={{ display: 'flex', gap: '8px', marginBottom: '20px' }}>
+                  {(['square', 'story'] as const).map((f) => (
+                    <button key={f} onClick={() => setPom((p) => ({ ...p, format: f }))} style={{
+                      flex: 1,
+                      padding: '10px',
+                      fontFamily: "'Bebas Neue', sans-serif",
+                      fontSize: '15px',
+                      letterSpacing: '3px',
+                      background: pomFormat === f ? 'rgba(204,0,0,0.18)' : 'rgba(255,255,255,0.04)',
+                      color: pomFormat === f ? '#FF3333' : 'rgba(255,255,255,0.35)',
+                      border: pomFormat === f ? '1px solid rgba(204,0,0,0.5)' : '1px solid rgba(255,255,255,0.08)',
+                      cursor: 'pointer',
+                      borderRadius: '2px',
+                      transition: 'all 0.15s',
+                    }}>
+                      {f === 'square' ? 'SQUARE 1:1' : 'STORY 9:16'}
+                    </button>
+                  ))}
+                </div>
+                <div style={{ display: 'flex', gap: '8px', marginBottom: '12px' }}>
+                  <div style={{ flex: 1 }}>
+                    <label style={labelStyle}>이름</label>
+                    <input style={inputStyle} value={pom.pomName}
+                      onChange={(e) => setPom((p) => ({ ...p, pomName: e.target.value }))} />
+                  </div>
+                  <div style={{ width: '60px', flexShrink: 0 }}>
+                    <label style={labelStyle}>등번호</label>
+                    <input style={inputStyle} value={pom.pomNumber}
+                      onChange={(e) => setPom((p) => ({ ...p, pomNumber: e.target.value }))} />
+                  </div>
+                  <div style={{ width: '70px', flexShrink: 0 }}>
+                    <label style={labelStyle}>포지션</label>
+                    <input style={inputStyle} value={pom.pomPosition}
+                      onChange={(e) => setPom((p) => ({ ...p, pomPosition: e.target.value }))} />
+                  </div>
+                </div>
+                <div style={fieldStyle}>
+                  <label style={labelStyle}>경기 라벨 (선택)</label>
+                  <input style={inputStyle} value={pom.matchLabel ?? ''}
+                    placeholder="e.g. 토토배 · 2026"
+                    onChange={(e) => setPom((p) => ({ ...p, matchLabel: e.target.value }))} />
+                </div>
+              </>
+            )}
+
+          {/* ── Match Result Friendly Form ── */}
+            {tab === 'result-friendly' && (
+              <>
+                <div style={fieldStyle}>
+                  <label style={labelStyle}>BADGE (경기 종류)</label>
+                  <input style={inputStyle} value={resultFriendly.badge}
+                    onChange={(e) => setResultFriendly((p) => ({ ...p, badge: e.target.value }))} />
+                </div>
+                <div style={fieldStyle}>
+                  <label style={labelStyle}>INFO DATE</label>
+                  <DatePicker value={resultFriendly.infoDate}
+                    onChange={(v) => setResultFriendly((p) => ({ ...p, infoDate: v }))} />
+                </div>
+                <div style={fieldStyle}>
+                  <label style={labelStyle}>INFO VENUE</label>
+                  <input style={inputStyle} value={resultFriendly.infoVenue}
+                    onChange={(e) => setResultFriendly((p) => ({ ...p, infoVenue: e.target.value }))} />
+                </div>
+                <div style={fieldStyle}>
+                  <label style={labelStyle}>AWAY TEAM</label>
+                  <input style={inputStyle} value={resultFriendly.awayTeam}
+                    onChange={(e) => setResultFriendly((p) => ({ ...p, awayTeam: e.target.value }))} />
+                </div>
+                <div style={fieldStyle}>
+                  <label style={labelStyle}>OPPONENT EMBLEM</label>
+                  <input type="file" accept="image/*"
+                    style={{ ...inputStyle, padding: '6px 12px', cursor: 'pointer' }}
+                    onChange={(e) => {
+                      const file = e.target.files?.[0];
+                      if (!file) return;
+                      const reader = new FileReader();
+                      reader.onload = (ev) => setResultFriendly((p) => ({ ...p, opponentImage: ev.target?.result as string }));
+                      reader.readAsDataURL(file);
+                    }} />
+                </div>
+                <div style={fieldStyle}>
+                  <label style={labelStyle}>팀 단체사진</label>
+                  <input type="file" accept="image/*"
+                    style={{ ...inputStyle, padding: '6px 12px', cursor: 'pointer' }}
+                    onChange={(e) => {
+                      const file = e.target.files?.[0];
+                      if (!file) return;
+                      const reader = new FileReader();
+                      reader.onload = (ev) => setResultFriendly((p) => ({ ...p, teamPhoto: ev.target?.result as string }));
+                      reader.readAsDataURL(file);
+                    }} />
+                </div>
+              </>
+            )}
+
           </div>
 
           {/* Download button */}
@@ -453,23 +790,21 @@ export default function Home() {
 
           {/* 스케일 래퍼 */}
           <div style={{
-            width: `${PREVIEW_SIZE}px`,
-            height: `${PREVIEW_SIZE}px`,
+            width: `${previewW}px`,
+            height: `${previewH}px`,
             overflow: 'hidden',
             boxShadow: '0 0 60px rgba(204,0,0,0.2), 0 0 120px rgba(0,0,0,0.8)',
           }}>
-            <div
-              style={{
-                transformOrigin: 'top left',
-                transform: `scale(${scale})`,
-                width: `${CARD_SIZE}px`,
-                height: `${CARD_SIZE}px`,
-              }}
-            >
+            <div style={{ transformOrigin: 'top left', transform: `scale(${previewScale})`, width: `${CARD_SIZE}px`, height: `${previewCardH}px` }}>
+
               {/* 미리보기용 (스케일 적용) */}
-              {tab === 'announcement' && <MatchAnnouncementTemplate data={announcement} />}
-              {tab === 'xi-real'      && <StartingXiATemplate data={xiReal} />}
-              {tab === 'xi-template1' && <StartingXiBTemplate data={xiT1} />}
+              {tab === 'announcement'      && <MatchAnnouncementTemplate data={announcement} />}
+              {tab === 'xi-real'           && <StartingXiATemplate data={xiReal} />}
+              {tab === 'xi-template1'      && <StartingXiBTemplate data={xiT1} />}
+              {tab === 'result-official'   && <MatchResultOfficialTemplate data={resultOfficial} />}
+              {tab === 'result-friendly'   && <MatchResultFriendlyTemplate data={resultFriendly} />}
+              {tab === 'pom' && pomVersion === 1 && <PlayerOfMatchTemplate data={pom} />}
+              {tab === 'pom' && pomVersion === 2 && <PlayerOfMatchV2Template data={pom} />}
             </div>
           </div>
 

--- a/components/templates/MatchAnnouncementTemplate.tsx
+++ b/components/templates/MatchAnnouncementTemplate.tsx
@@ -148,7 +148,7 @@ const styles = {
   timeBlockVenueValue: {
     fontSize: '40px',
     fontFamily: "'Bebas Neue', sans-serif",
-    fontWeight: 700,
+    fontWeight: 600,
     letterSpacing: '1px',
     color: '#fff',
     lineHeight: 1,

--- a/components/templates/MatchResultFriendlyTemplate.tsx
+++ b/components/templates/MatchResultFriendlyTemplate.tsx
@@ -1,0 +1,124 @@
+import { MatchResultFriendlyData } from '@/types';
+import RuntimeLogo from './RuntimeLogo';
+import { TemplateCanvas } from './shared/TemplateCanvas';
+import { SpeedLinesBg } from './shared/SpeedLinesBg';
+import { VignetteOverlay } from './shared/VignetteOverlay';
+import { BottomBar } from './shared/BottomBar';
+
+interface Props {
+  data: MatchResultFriendlyData;
+}
+
+const VIGNETTE = 'radial-gradient(ellipse 75% 75% at 50% 40%, rgba(0,0,0,0.93) 25%, transparent 100%)';
+
+const OpponentShield = () => (
+  <svg viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg" width="90" height="90" style={{ opacity: 0.45 }}>
+    <path d="M50 8 L88 22 L88 52 C88 72 70 88 50 94 C30 88 12 72 12 52 L12 22 Z"
+      fill="rgba(255,255,255,0.05)" stroke="rgba(255,255,255,0.35)" strokeWidth="2.5" />
+    <path d="M50 18 L80 29 L80 52 C80 67 66 80 50 85 C34 80 20 67 20 52 L20 29 Z"
+      fill="none" stroke="rgba(255,255,255,0.15)" strokeWidth="1.5" />
+  </svg>
+);
+
+export default function MatchResultFriendlyTemplate({ data }: Props) {
+  return (
+    <TemplateCanvas>
+      <SpeedLinesBg filterId="blur-result-friendly" />
+      <VignetteOverlay gradient={VIGNETTE} />
+
+      <div style={{
+        position: 'relative', zIndex: 2,
+        width: '100%', height: '100%',
+        display: 'flex', flexDirection: 'column', alignItems: 'center',
+        padding: '52px 80px 50px',
+        boxSizing: 'border-box',
+      }}>
+
+        {/* Logo */}
+        <RuntimeLogo width={82} height={93} color="white"
+          style={{ filter: 'drop-shadow(0 0 14px rgba(255,255,255,0.12))', flexShrink: 0 }} />
+        <div style={{
+          width: '70px', height: '2px',
+          background: 'linear-gradient(90deg, transparent, #CC0000, transparent)',
+          margin: '8px 0 18px',
+          flexShrink: 0,
+        }} />
+
+        {/* Info line */}
+        <div style={{
+          fontFamily: "'Noto Sans KR', sans-serif",
+          fontSize: '19px', color: 'rgba(255,255,255,0.7)',
+          letterSpacing: '0.5px', marginBottom: '26px', flexShrink: 0,
+        }}>
+          <span style={{ color: '#FF4444', fontWeight: 700 }}>[{data.badge}]</span>
+          {' '}{data.infoDate}/{data.infoVenue}
+        </div>
+
+        {/* Section label */}
+        <div style={{
+          fontFamily: "'Bebas Neue', sans-serif",
+          fontSize: '20px', letterSpacing: '6px',
+          color: 'rgba(255,255,255,0.4)',
+          marginBottom: '28px', flexShrink: 0,
+        }}>
+          Matchup
+        </div>
+
+        {/* Matchup row */}
+        <div style={{
+          display: 'flex', alignItems: 'center', justifyContent: 'center',
+          gap: '60px', width: '100%', marginBottom: '22px', flexShrink: 0,
+        }}>
+          {/* RUNTIME */}
+          <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: '12px' }}>
+            <RuntimeLogo width={148} height={168} color="white"
+              style={{ filter: 'drop-shadow(0 0 16px rgba(204,0,0,0.4))' }} />
+            <div style={{
+              fontFamily: "'Bebas Neue', sans-serif",
+              fontSize: '24px', letterSpacing: '5px', color: 'rgba(255,255,255,0.85)',
+            }}>RUNTIME</div>
+          </div>
+
+          {/* Opponent */}
+          <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: '12px' }}>
+            <div style={{
+              width: '160px', height: '160px',
+              border: '2px solid rgba(255,255,255,0.12)',
+              background: 'rgba(10,10,10,0.8)',
+              display: 'flex', alignItems: 'center', justifyContent: 'center',
+              clipPath: 'polygon(12px 0%, 100% 0%, calc(100% - 12px) 100%, 0% 100%)',
+            }}>
+              {data.opponentImage ? (
+                // eslint-disable-next-line @next/next/no-img-element
+                <img src={data.opponentImage} alt={data.awayTeam}
+                  style={{ width: '100%', height: '100%', objectFit: 'contain' }} />
+              ) : <OpponentShield />}
+            </div>
+            <div style={{
+              fontFamily: "'Bebas Neue', sans-serif",
+              fontSize: '24px', letterSpacing: '5px', color: 'rgba(255,255,255,0.85)',
+            }}>{data.awayTeam}</div>
+          </div>
+        </div>
+
+        {/* Dot separator */}
+        <div style={{
+          width: '6px', height: '6px', borderRadius: '50%',
+          background: 'rgba(204,0,0,0.6)',
+          marginBottom: '22px', flexShrink: 0,
+        }} />
+
+        {/* Team photo */}
+        {data.teamPhoto && (
+          <div style={{ flex: 1, width: '100%', overflow: 'hidden', minHeight: 0 }}>
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img src={data.teamPhoto} alt="team"
+              style={{ width: '100%', height: '100%', objectFit: 'cover', display: 'block' }} />
+          </div>
+        )}
+      </div>
+
+      <BottomBar />
+    </TemplateCanvas>
+  );
+}

--- a/components/templates/MatchResultOfficialTemplate.tsx
+++ b/components/templates/MatchResultOfficialTemplate.tsx
@@ -1,0 +1,298 @@
+import { MatchResultOfficialData } from '@/types';
+import { SportShoe } from 'lucide-react';
+import RuntimeLogo from './RuntimeLogo';
+import { TemplateCanvas } from './shared/TemplateCanvas';
+import { SpeedLinesBg } from './shared/SpeedLinesBg';
+import { VignetteOverlay } from './shared/VignetteOverlay';
+import { BottomBar } from './shared/BottomBar';
+
+interface Props {
+  data: MatchResultOfficialData;
+}
+
+const VIGNETTE = 'radial-gradient(ellipse 75% 75% at 50% 42%, rgba(0,0,0,0.93) 25%, transparent 100%)';
+
+// 클래식 텔스타 패턴 축구공 SVG (오각형 + 5개 선)
+const SoccerBall = ({ size = 20, color = 'rgba(255,255,255,0.82)', strokeWidth = 1.5 }: {
+  size?: number; color?: string; strokeWidth?: number;
+}) => (
+  <svg width={size} height={size} viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+    {/* 외부 원 */}
+    <circle cx="10" cy="10" r="9" stroke={color} strokeWidth={strokeWidth} />
+    {/* 중앙 오각형 — 꼭짓점 순서: 위→오른쪽→오른쪽아래→왼쪽아래→왼쪽 */}
+    <polygon
+      points="10,6.5 13.33,8.92 12.06,12.83 7.94,12.83 6.67,8.92"
+      stroke={color} strokeWidth={strokeWidth} fill="none"
+    />
+    {/* 오각형 꼭짓점 → 원 가장자리 5개 선 */}
+    <line x1="10"    y1="6.5"  x2="10"    y2="1"     stroke={color} strokeWidth={strokeWidth} />
+    <line x1="13.33" y1="8.92" x2="18.56" y2="7.22"  stroke={color} strokeWidth={strokeWidth} />
+    <line x1="12.06" y1="12.83" x2="15.29" y2="17.28" stroke={color} strokeWidth={strokeWidth} />
+    <line x1="7.94"  y1="12.83" x2="4.71"  y2="17.28" stroke={color} strokeWidth={strokeWidth} />
+    <line x1="6.67"  y1="8.92" x2="1.44"  y2="7.22"  stroke={color} strokeWidth={strokeWidth} />
+  </svg>
+);
+
+const OpponentShield = () => (
+  <svg viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg" width="96" height="96" style={{ opacity: 0.45 }}>
+    <path d="M50 8 L88 22 L88 52 C88 72 70 88 50 94 C30 88 12 72 12 52 L12 22 Z"
+      fill="rgba(255,255,255,0.05)" stroke="rgba(255,255,255,0.35)" strokeWidth="2.5" />
+    <path d="M50 18 L80 29 L80 52 C80 67 66 80 50 85 C34 80 20 67 20 52 L20 29 Z"
+      fill="none" stroke="rgba(255,255,255,0.15)" strokeWidth="1.5" />
+  </svg>
+);
+
+const PhotoPlaceholder = ({ label }: { label: string }) => (
+  <div style={{
+    width: '100%', height: '100%',
+    background: 'rgba(255,255,255,0.05)',
+    border: '1px solid rgba(255,255,255,0.1)',
+    display: 'flex', alignItems: 'center', justifyContent: 'center',
+  }}>
+    <span style={{
+      fontFamily: "'Bebas Neue', sans-serif",
+      fontSize: '16px', letterSpacing: '4px',
+      color: 'rgba(255,255,255,0.2)',
+    }}>{label}</span>
+  </div>
+);
+
+export default function MatchResultOfficialTemplate({ data }: Props) {
+  return (
+    <TemplateCanvas>
+      <SpeedLinesBg filterId="blur-result-official" />
+      <VignetteOverlay gradient={VIGNETTE} />
+
+      <div style={{
+        position: 'relative', zIndex: 2,
+        width: '100%', height: '100%',
+        display: 'flex', flexDirection: 'column', alignItems: 'center',
+        padding: '44px 72px 48px',
+        boxSizing: 'border-box',
+      }}>
+
+        {/* Logo */}
+        <RuntimeLogo width={98} height={112} color="white"
+          style={{ filter: 'drop-shadow(0 0 14px rgba(255,255,255,0.12))', flexShrink: 0 }} />
+        <div style={{
+          width: '84px', height: '2px',
+          background: 'linear-gradient(90deg, transparent, #CC0000, transparent)',
+          margin: '8px 0 14px',
+          flexShrink: 0,
+        }} />
+
+        {/* Info block — 2행 계층 구조 */}
+        <div style={{
+          display: 'flex', flexDirection: 'column', alignItems: 'center',
+          gap: '8px', marginBottom: '20px', flexShrink: 0,
+        }}>
+          {/* Row 1: badge + thin bar + date */}
+          <div style={{ display: 'flex', alignItems: 'center', gap: '14px' }}>
+            {/* Competition badge */}
+            <div style={{
+              background: 'rgba(204,0,0,0.18)',
+              border: '1px solid rgba(204,0,0,0.65)',
+              color: '#FF4444',
+              fontFamily: "'Bebas Neue', sans-serif",
+              fontSize: '17px', letterSpacing: '4px',
+              padding: '5px 18px 4px',
+              clipPath: 'polygon(8px 0%, 100% 0%, calc(100% - 8px) 100%, 0% 100%)',
+            }}>{data.badge}</div>
+
+            {/* Thin vertical divider */}
+            <div style={{ width: '1px', height: '20px', background: 'rgba(204,0,0,0.4)' }} />
+
+            {/* Date — Bebas Neue, prominent */}
+            <span style={{
+              fontFamily: "'Bebas Neue', sans-serif",
+              fontSize: '22px', letterSpacing: '4px',
+              color: 'rgba(255,255,255,0.75)',
+            }}>{data.infoDate}</span>
+          </div>
+
+          {/* Row 2: venue — smaller, letter-spaced, muted */}
+          <span style={{
+            fontFamily: "'Noto Sans KR', sans-serif",
+            fontSize: '13px', letterSpacing: '2px',
+            color: 'rgba(255,255,255,0.32)',
+          }}>{data.infoVenue}</span>
+        </div>
+
+        {/* Thin divider before matchup */}
+        <div style={{
+          display: 'flex', alignItems: 'center', gap: '14px',
+          width: '100%', marginBottom: '16px', flexShrink: 0,
+        }}>
+          <div style={{ flex: 1, height: '1px', background: 'linear-gradient(90deg, transparent, rgba(204,0,0,0.35))' }} />
+          <span style={{
+            fontFamily: "'Bebas Neue', sans-serif",
+            fontSize: '13px', letterSpacing: '8px',
+            color: 'rgba(255,255,255,0.2)',
+          }}>MATCH RESULT</span>
+          <div style={{ flex: 1, height: '1px', background: 'linear-gradient(270deg, transparent, rgba(204,0,0,0.35))' }} />
+        </div>
+
+        {/* Matchup row */}
+        <div style={{
+          display: 'flex', alignItems: 'center', justifyContent: 'center',
+          gap: '20px', width: '100%', marginBottom: '18px', flexShrink: 0,
+        }}>
+          {/* RUNTIME */}
+          <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: '10px', flex: 1 }}>
+            <RuntimeLogo width={144} height={163} color="white"
+              style={{ filter: 'drop-shadow(0 0 18px rgba(204,0,0,0.5))' }} />
+            <div style={{
+              fontFamily: "'Bebas Neue', sans-serif",
+              fontSize: '26px', letterSpacing: '5px', color: 'rgba(255,255,255,0.85)',
+            }}>RUNTIME</div>
+          </div>
+
+          {/* Score */}
+          <div style={{ flexShrink: 0, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+            <div style={{
+              fontFamily: "'Bebas Neue', sans-serif",
+              fontSize: '182px', color: '#CC0000', lineHeight: 1,
+              letterSpacing: '8px',
+              textShadow: '0 0 50px rgba(204,0,0,0.8), 0 0 100px rgba(204,0,0,0.4)',
+            }}>
+              {data.homeScore}-{data.awayScore}
+            </div>
+          </div>
+
+          {/* Opponent */}
+          <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: '10px', flex: 1 }}>
+            <div style={{
+              width: '163px', height: '163px',
+              border: '2px solid rgba(255,255,255,0.12)',
+              background: 'rgba(10,10,10,0.8)',
+              display: 'flex', alignItems: 'center', justifyContent: 'center',
+              clipPath: 'polygon(12px 0%, 100% 0%, calc(100% - 12px) 100%, 0% 100%)',
+            }}>
+              {data.opponentImage ? (
+                // eslint-disable-next-line @next/next/no-img-element
+                <img src={data.opponentImage} alt={data.awayTeam}
+                  style={{ width: '100%', height: '100%', objectFit: 'contain' }} />
+              ) : <OpponentShield />}
+            </div>
+            <div style={{
+              fontFamily: "'Bebas Neue', sans-serif",
+              fontSize: '26px', letterSpacing: '5px', color: 'rgba(255,255,255,0.85)',
+            }}>{data.awayTeam}</div>
+          </div>
+        </div>
+
+        {/* Dot separator */}
+        <div style={{
+          width: '7px', height: '7px', borderRadius: '50%',
+          background: 'rgba(204,0,0,0.6)',
+          marginBottom: '18px', flexShrink: 0,
+        }} />
+
+        {/* Bottom: GOALS + 단체사진 (세로 스택, 전체 너비) */}
+        <div style={{
+          display: 'flex', flexDirection: 'column', width: '100%', flex: 1, minHeight: 0, gap: '14px',
+        }}>
+
+          {/* GOALS + POM — 가로 배치 */}
+          <div style={{ display: 'flex', gap: '0px', flexShrink: 0 }}>
+
+            {/* GOALS */}
+            <div style={{ display: 'flex', flexDirection: 'column', paddingLeft: '50px', flex: 1 }}>
+              <div style={{ display: 'flex', alignItems: 'center', gap: '8px', marginBottom: '14px' }}>
+                <div style={{ width: '3px', height: '22px', background: '#CC0000', borderRadius: '2px', flexShrink: 0 }} />
+                <span style={{
+                  fontFamily: "'Bebas Neue', sans-serif",
+                  fontSize: '19px', letterSpacing: '6px',
+                  color: 'rgba(255,255,255,0.45)',
+                }}>GOALS</span>
+              </div>
+              <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
+                {data.scorers.map((s, i) => (
+                  <div key={i} style={{ display: 'flex', alignItems: 'center' }}>
+                    <div style={{ width: '34px', flexShrink: 0, display: 'flex', alignItems: 'center' }}>
+                      <SoccerBall size={20} />
+                    </div>
+                    <div style={{ width: '56px', flexShrink: 0 }}>
+                      <span style={{
+                        fontFamily: "'Bebas Neue', sans-serif",
+                        fontSize: '22px', lineHeight: 1,
+                        color: 'rgba(204,0,0,0.9)', letterSpacing: '1px',
+                      }}>{s.minute}&apos;</span>
+                    </div>
+                    <div style={{ width: '160px', flexShrink: 0 }}>
+                      <span style={{
+                        fontFamily: "'Noto Sans KR', sans-serif",
+                        fontSize: '20px', lineHeight: 1,
+                        color: 'rgba(255,255,255,0.95)',
+                        fontWeight: 700, letterSpacing: '1.5px',
+                      }}>{s.name}</span>
+                    </div>
+                    {s.assist && s.assist.trim() !== '' && (
+                      <>
+                        <div style={{ width: '28px', flexShrink: 0, display: 'flex', alignItems: 'center' }}>
+                          <SportShoe size={18} color="rgba(255,255,255,0.3)" strokeWidth={1.5} />
+                        </div>
+                        <span style={{
+                          fontFamily: "'Noto Sans KR', sans-serif",
+                          fontSize: '18px', lineHeight: 1,
+                          color: 'rgba(255,255,255,0.45)',
+                        }}>{s.assist}</span>
+                      </>
+                    )}
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            {/* POM — GOALS 라벨 기준선에 맞춰 상단 정렬 */}
+            <div style={{
+              display: 'flex', flexDirection: 'column', alignItems: 'flex-start',
+              justifyContent: 'flex-start', paddingRight: '140px', gap: '6px',
+              flexShrink: 0,
+            }}>
+              {/* POM 라벨 */}
+              <div style={{ display: 'flex', alignItems: 'center', gap: '8px', marginBottom: '2px' }}>
+                <div style={{ width: '3px', height: '22px', background: '#CC0000', borderRadius: '2px' }} />
+                <span style={{
+                  fontFamily: "'Bebas Neue', sans-serif",
+                  fontSize: '19px', letterSpacing: '6px',
+                  color: 'rgba(255,255,255,0.45)',
+                }}>POM</span>
+              </div>
+
+              {/* #번호 이름 */}
+              <div style={{ display: 'flex', alignItems: 'baseline', gap: '10px' }}>
+                <span style={{
+                  fontFamily: "'Bebas Neue', sans-serif",
+                  fontSize: '44px', lineHeight: 1,
+                  color: '#CC0000',
+                  textShadow: '0 0 30px rgba(204,0,0,0.5)',
+                  letterSpacing: '2px',
+                }}>#{data.pomNumber}</span>
+                <span style={{
+                  fontFamily: "'Noto Sans KR', sans-serif",
+                  fontSize: '22px', fontWeight: 700,
+                  color: 'rgba(255,255,255,0.92)',
+                  letterSpacing: '2px',
+                }}>{data.pomName}</span>
+              </div>
+            </div>
+          </div>
+
+          {/* 단체사진 — 나머지 공간 전부 */}
+          <div style={{ flex: 1, width: '100%', overflow: 'hidden', minHeight: 0, paddingLeft: '50px', paddingRight: '50px', boxSizing: 'border-box' }}>
+            {data.teamPhoto ? (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img src={data.teamPhoto} alt="team"
+                style={{ width: '100%', height: '100%', objectFit: 'cover', display: 'block' }} />
+            ) : (
+              <PhotoPlaceholder label="TEAM PHOTO" />
+            )}
+          </div>
+        </div>
+      </div>
+
+      <BottomBar />
+    </TemplateCanvas>
+  );
+}

--- a/components/templates/PlayerOfMatchTemplate.tsx
+++ b/components/templates/PlayerOfMatchTemplate.tsx
@@ -1,0 +1,189 @@
+import { PlayerOfMatchData } from '@/types';
+import RuntimeLogo from './RuntimeLogo';
+import { BottomBar } from './shared/BottomBar';
+
+interface Props {
+  data: PlayerOfMatchData;
+}
+
+export default function PlayerOfMatchTemplate({ data }: Props) {
+  const H = data.format === 'story' ? 1920 : 1080;
+  return (
+    <div style={{
+      width: '1080px',
+      height: `${H}px`,
+      position: 'relative',
+      overflow: 'hidden',
+      background: '#080808',
+    }}>
+
+      {/* 선수 사진 — 풀블리드 배경 */}
+      {data.pomPhoto ? (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img
+          src={data.pomPhoto}
+          alt={data.pomName}
+          style={{
+            position: 'absolute',
+            inset: 0,
+            width: '100%',
+            height: '100%',
+            objectFit: 'cover',
+            objectPosition: `${data.pomPhotoX ?? 50}% ${data.pomPhotoY ?? 0}%`,
+          }}
+        />
+      ) : (
+        <div style={{
+          position: 'absolute',
+          inset: 0,
+          background: 'linear-gradient(135deg, #1a1a1a 0%, #0a0a0a 100%)',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}>
+          <span style={{
+            fontFamily: "'Bebas Neue', sans-serif",
+            fontSize: '28px',
+            letterSpacing: '8px',
+            color: 'rgba(255,255,255,0.1)',
+          }}>PLAYER PHOTO</span>
+        </div>
+      )}
+
+      {/* 그라디언트 오버레이 — 상단·하단 어둡게 */}
+      <div style={{
+        position: 'absolute',
+        inset: 0,
+        background: 'linear-gradient(to bottom, rgba(0,0,0,0.72) 0%, rgba(0,0,0,0.1) 35%, rgba(0,0,0,0.08) 55%, rgba(0,0,0,0.85) 100%)',
+        zIndex: 1,
+      }} />
+
+      {/* 콘텐츠 레이어 */}
+      <div style={{
+        position: 'absolute',
+        inset: 0,
+        zIndex: 2,
+      }}>
+
+        {/* ── 상단 좌측: PLAYER OF THE MATCH ── */}
+        <div style={{
+          position: 'absolute',
+          top: '52px',
+          left: '60px',
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 0,
+          lineHeight: 0.88,
+        }}>
+          <span style={{
+            fontFamily: "'Bebas Neue', sans-serif",
+            fontSize: '168px',
+            color: '#ffffff',
+            letterSpacing: '-2px',
+            textShadow: '0 4px 40px rgba(0,0,0,0.6)',
+            display: 'block',
+          }}>PLAYER</span>
+          <span style={{
+            fontFamily: "'Bebas Neue', sans-serif",
+            fontSize: '68px',
+            color: 'rgba(255,255,255,0.65)',
+            letterSpacing: '12px',
+            display: 'block',
+            marginTop: '4px',
+          }}>OF THE</span>
+          <span style={{
+            fontFamily: "'Bebas Neue', sans-serif",
+            fontSize: '168px',
+            color: '#CC0000',
+            letterSpacing: '-2px',
+            textShadow: '0 0 60px rgba(204,0,0,0.7), 0 4px 40px rgba(0,0,0,0.5)',
+            display: 'block',
+          }}>MATCH</span>
+        </div>
+
+        {/* ── 상단 우측: RUNTIME 로고 ── */}
+        <div style={{
+          position: 'absolute',
+          top: '52px',
+          right: '60px',
+        }}>
+          <RuntimeLogo width={64} height={73} color="white"
+            style={{ opacity: 0.8, filter: 'drop-shadow(0 2px 12px rgba(0,0,0,0.6))' }} />
+        </div>
+
+        {/* ── 하단: 선수 정보 블록 ── */}
+        <div style={{
+          position: 'absolute',
+          bottom: '42px',
+          left: 0,
+          right: 0,
+          padding: '0 60px',
+          display: 'flex',
+          alignItems: 'flex-end',
+          justifyContent: 'space-between',
+        }}>
+
+          {/* 왼쪽: 이름 + 경기 정보 */}
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '6px' }}>
+            {data.matchLabel && (
+              <span style={{
+                fontFamily: "'Bebas Neue', sans-serif",
+                fontSize: '22px',
+                letterSpacing: '6px',
+                color: 'rgba(255,255,255,0.45)',
+              }}>{data.matchLabel}</span>
+            )}
+            <div style={{
+              width: '56px',
+              height: '3px',
+              background: '#CC0000',
+              borderRadius: '2px',
+              marginBottom: '4px',
+            }} />
+            <span style={{
+              fontFamily: "'Noto Sans KR', sans-serif",
+              fontSize: '72px',
+              fontWeight: 900,
+              color: '#ffffff',
+              lineHeight: 1,
+              letterSpacing: '2px',
+              textShadow: '0 2px 24px rgba(0,0,0,0.8)',
+            }}>{data.pomName}</span>
+          </div>
+
+          {/* 오른쪽: 등번호 + 포지션 */}
+          <div style={{
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'flex-end',
+            gap: '2px',
+          }}>
+            <span style={{
+              fontFamily: "'Bebas Neue', sans-serif",
+              fontSize: '130px',
+              lineHeight: 1,
+              color: '#CC0000',
+              letterSpacing: '-2px',
+              textShadow: '0 0 50px rgba(204,0,0,0.8), 0 2px 24px rgba(0,0,0,0.6)',
+            }}>#{data.pomNumber}</span>
+            <div style={{
+              background: 'rgba(204,0,0,0.2)',
+              border: '1px solid rgba(204,0,0,0.6)',
+              padding: '6px 20px 5px',
+              clipPath: 'polygon(6px 0%, 100% 0%, calc(100% - 6px) 100%, 0% 100%)',
+            }}>
+              <span style={{
+                fontFamily: "'Bebas Neue', sans-serif",
+                fontSize: '28px',
+                letterSpacing: '6px',
+                color: '#FF4444',
+              }}>{data.pomPosition}</span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <BottomBar />
+    </div>
+  );
+}

--- a/components/templates/PlayerOfMatchV2Template.tsx
+++ b/components/templates/PlayerOfMatchV2Template.tsx
@@ -1,0 +1,92 @@
+import { PlayerOfMatchData } from '@/types';
+import { BottomBar } from './shared/BottomBar';
+
+interface Props {
+  data: PlayerOfMatchData;
+}
+
+export default function PlayerOfMatchV2Template({ data }: Props) {
+  const H = data.format === 'story' ? 1920 : 1080;
+  return (
+    <div style={{
+      width: '1080px',
+      height: `${H}px`,
+      position: 'relative',
+      overflow: 'hidden',
+      background: '#080808',
+    }}>
+
+      {/* 선수 사진 — 풀블리드 */}
+      {data.pomPhoto ? (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img
+          src={data.pomPhoto}
+          alt={data.pomName}
+          style={{
+            position: 'absolute',
+            inset: 0,
+            width: '100%',
+            height: '100%',
+            objectFit: 'cover',
+            objectPosition: `${data.pomPhotoX ?? 50}% ${data.pomPhotoY ?? 0}%`,
+          }}
+        />
+      ) : (
+        <div style={{
+          position: 'absolute',
+          inset: 0,
+          background: 'linear-gradient(135deg, #1a1a1a 0%, #0a0a0a 100%)',
+        }} />
+      )}
+
+      {/* 미묘한 비네트 — 모서리만 살짝 */}
+      <div style={{
+        position: 'absolute',
+        inset: 0,
+        background: 'radial-gradient(ellipse at center, transparent 40%, rgba(0,0,0,0.45) 100%)',
+        zIndex: 1,
+      }} />
+
+      {/* 텍스트 레이어 */}
+      <div style={{ position: 'absolute', inset: 0, zIndex: 2 }}>
+
+        {/* THIS — 상단 좌측 */}
+        <span style={{
+          position: 'absolute',
+          top: '36px',
+          left: '48px',
+          fontFamily: "'Bebas Neue', sans-serif",
+          fontSize: '260px',
+          lineHeight: 0.85,
+          color: '#ffffff',
+          letterSpacing: '-4px',
+          textShadow: '4px 4px 0px rgba(0,0,0,0.35)',
+          userSelect: 'none',
+          display: 'block',
+          transform: 'scaleY(1.45)',
+          transformOrigin: 'top left',
+        }}>THIS</span>
+
+        {/* IS — 하단 우측 */}
+        <span style={{
+          position: 'absolute',
+          bottom: '36px',
+          right: '48px',
+          fontFamily: "'Bebas Neue', sans-serif",
+          fontSize: '260px',
+          lineHeight: 0.85,
+          color: '#ffffff',
+          letterSpacing: '-4px',
+          textShadow: '4px 4px 0px rgba(0,0,0,0.35)',
+          userSelect: 'none',
+          display: 'block',
+          transform: 'scaleY(1.45)',
+          transformOrigin: 'bottom right',
+        }}>IS</span>
+
+      </div>
+
+      <BottomBar />
+    </div>
+  );
+}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "html-to-image": "^1.11.13",
         "html2canvas": "^1.4.1",
+        "lucide-react": "^1.6.0",
         "next": "^16.2.1",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
@@ -760,6 +761,15 @@
       },
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.6.0.tgz",
+      "integrity": "sha512-YxLKVCOF5ZDI1AhKQE5IBYMY9y/Nr4NT15+7QEWpsTSVCdn4vmZhww+6BP76jWYjQx8rSz1Z+gGme1f+UycWEw==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/nanoid": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "html-to-image": "^1.11.13",
     "html2canvas": "^1.4.1",
+    "lucide-react": "^1.6.0",
     "next": "^16.2.1",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"

--- a/types/index.ts
+++ b/types/index.ts
@@ -29,3 +29,45 @@ export interface StartingXiData {
   players: Player[];
   substitutes: SubPlayer[];
 }
+
+export interface Scorer {
+  minute: string;
+  name: string;
+  assist?: string;
+}
+
+export interface MatchResultOfficialData {
+  badge: string;
+  infoDate: string;
+  infoVenue: string;
+  awayTeam: string;
+  homeScore: string;
+  awayScore: string;
+  scorers: Scorer[];
+  teamPhoto?: string;
+  pomPhoto?: string;
+  pomName: string;
+  pomNumber: string;
+  pomPosition: string;
+  opponentImage?: string;
+}
+
+export interface PlayerOfMatchData {
+  pomPhoto?: string;
+  pomPhotoX?: number; // 0~100, default 50
+  pomPhotoY?: number; // 0~100, default 0
+  pomName: string;
+  pomNumber: string;
+  pomPosition: string;
+  matchLabel?: string;
+  format?: 'square' | 'story'; // square=1080x1080, story=1080x1920
+}
+
+export interface MatchResultFriendlyData {
+  badge: string;
+  infoDate: string;
+  infoVenue: string;
+  awayTeam: string;
+  teamPhoto?: string;
+  opponentImage?: string;
+}


### PR DESCRIPTION
## Summary
- 경기 결과 템플릿 추가 (친선전/공식전)
- 이달의 선수(Player of Match) 템플릿 추가 (v1, v2)
- 관련 타입 및 페이지 UI 업데이트

## Test plan
- [ ] 경기 결과 친선전 템플릿 렌더링 확인
- [ ] 경기 결과 공식전 템플릿 렌더링 확인
- [ ] 이달의 선수 템플릿 렌더링 확인
- [ ] 이미지 캡처/다운로드 동작 확인