### PR TITLE
fix: XI 템플릿 글자 색 및 배경 변경

### DIFF
--- a/components/templates/StartingXiATemplate.tsx
+++ b/components/templates/StartingXiATemplate.tsx
@@ -141,7 +141,7 @@ const styles = {
   playerNumber: {
     fontFamily: "'Bebas Neue', sans-serif",
     fontSize: '39px',
-    color: 'rgba(180,0,0,0.5)',
+    color: 'rgba(180,0,0,0.9)',
     lineHeight: 1,
     width: '59px',
     flexShrink: 0,

--- a/components/templates/shared/SpeedLinesDiagonalBg.tsx
+++ b/components/templates/shared/SpeedLinesDiagonalBg.tsx
@@ -28,7 +28,7 @@ export function SpeedLinesDiagonalBg({ filterId, gradientId, maskId }: SpeedLine
 
       <g mask={`url(#${maskId})`} filter={`url(#${filterId})`}>
         {/* Primary diagonal lines */}
-        <g opacity="0.9">
+        <g opacity="0.6">
           <line x1="-30" y1="0"    x2="1110" y2="410"  stroke="#CC0000" strokeWidth="3.5" />
           <line x1="-30" y1="50"   x2="1110" y2="460"  stroke="#880000" strokeWidth="1.5" />
           <line x1="-30" y1="105"  x2="1110" y2="515"  stroke="#FF2222" strokeWidth="2.5" />
@@ -61,7 +61,7 @@ export function SpeedLinesDiagonalBg({ filterId, gradientId, maskId }: SpeedLine
         </g>
 
         {/* Accent lines (bright) */}
-        <g opacity="1">
+        <g opacity="0.4">
           <line x1="-30" y1="30"  x2="1110" y2="440"  stroke="#FF2222" strokeWidth="4.5" />
           <line x1="-30" y1="280" x2="1110" y2="690"  stroke="#FF2222" strokeWidth="3.5" />
           <line x1="-30" y1="580" x2="1110" y2="990"  stroke="#FF3333" strokeWidth="4" />


### PR DESCRIPTION
Closes #3

## 변경 사항

- 선수 번호 색상 `rgba(180,0,0,0.5)` → `rgba(180,0,0,0.9)` 으로 가시성 개선
- 배경 대각선 Primary opacity `0.9` → `0.6`, Accent opacity `1.0` → `0.4` 로 조정