### PR TITLE
feat: Match Announcement 템플릿 UI 개선

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -22,19 +22,21 @@ function todayStr() {
   return `${y}.${m}.${d}`;
 }
 
-function infoDateToMatchDate(infoDate: string) {
-  const parts = infoDate.split('.');
-  return parts.length >= 3 ? `${parts[1]} / ${parts[2]}` : infoDate;
+function dateToMatchDate(yyyymmdd: string): string {
+  const parts = yyyymmdd.split('.');
+  if (parts.length !== 3) return yyyymmdd;
+  return `${parts[1]} / ${parts[2]}`;
 }
 
 // ── 기본값 ──────────────────────────────────────────────
 const _today = todayStr();
 const DEFAULT_ANNOUNCEMENT: MatchAnnouncementData = {
   badge: 'MATCH PREVIEW',
-  infoDate: _today,
+  competition: '토토배 8강',
+  infoDate: todayStr(),
   infoVenue: '동국대학교 대운동장',
   awayTeam: '3AM',
-  matchDate: infoDateToMatchDate(_today),
+  matchDate: dateToMatchDate(todayStr()),
   kickoffTime: '18 : 00',
   venueShort: '대운동장',
 };
@@ -68,9 +70,9 @@ const DEFAULT_RESULT_OFFICIAL: MatchResultOfficialData = {
 };
 
 const DEFAULT_POM: PlayerOfMatchData = {
-  pomName: '공가훈',
-  pomNumber: '10',
-  pomPosition: 'MF',
+  pomName: '',
+  pomNumber: '7',
+  pomPosition: '',
   matchLabel: '토토배 · 2026',
 };
 
@@ -262,22 +264,23 @@ export default function Home() {
             {tab === 'announcement' && (
               <>
                 <div style={fieldStyle}>
-                  <label style={labelStyle}>BADGE TEXT</label>
-                  <input style={inputStyle} value={announcement.badge}
-                    onChange={(e) => setAnnouncement((p) => ({ ...p, badge: e.target.value }))} />
+                  <label style={labelStyle}>대회</label>
+                  <input style={inputStyle} value={announcement.competition}
+                    placeholder="토토배 8강"
+                    onChange={(e) => setAnnouncement((p) => ({ ...p, competition: e.target.value }))} />
                 </div>
                 <div style={fieldStyle}>
-                  <label style={labelStyle}>INFO DATE</label>
+                  <label style={labelStyle}>날짜</label>
                   <DatePicker value={announcement.infoDate}
-                    onChange={(v) => setAnnouncement((p) => ({ ...p, infoDate: v, matchDate: infoDateToMatchDate(v) }))} />
+                    onChange={(v) => setAnnouncement((p) => ({ ...p, infoDate: v, matchDate: dateToMatchDate(v) }))} />
                 </div>
                 <div style={fieldStyle}>
-                  <label style={labelStyle}>INFO VENUE</label>
+                  <label style={labelStyle}>장소</label>
                   <input style={inputStyle} value={announcement.infoVenue}
                     onChange={(e) => setAnnouncement((p) => ({ ...p, infoVenue: e.target.value }))} />
                 </div>
                 <div style={fieldStyle}>
-                  <label style={labelStyle}>AWAY TEAM</label>
+                  <label style={labelStyle}>상대팀</label>
                   <input style={inputStyle} value={announcement.awayTeam}
                     onChange={(e) => setAnnouncement((p) => ({ ...p, awayTeam: e.target.value }))} />
                 </div>
@@ -317,17 +320,12 @@ export default function Home() {
                   )}
                 </div>
                 <div style={fieldStyle}>
-                  <label style={labelStyle}>DATE (하단 표시)</label>
-                  <input style={inputStyle} value={announcement.matchDate}
-                    onChange={(e) => setAnnouncement((p) => ({ ...p, matchDate: e.target.value }))} />
-                </div>
-                <div style={fieldStyle}>
-                  <label style={labelStyle}>KICKOFF TIME</label>
+                  <label style={labelStyle}>시간</label>
                   <input style={inputStyle} value={announcement.kickoffTime}
                     onChange={(e) => setAnnouncement((p) => ({ ...p, kickoffTime: e.target.value }))} />
                 </div>
                 <div style={fieldStyle}>
-                  <label style={labelStyle}>VENUE SHORT</label>
+                  <label style={labelStyle}>장소 (짧게)</label>
                   <input style={inputStyle} value={announcement.venueShort}
                     onChange={(e) => setAnnouncement((p) => ({ ...p, venueShort: e.target.value }))} />
                 </div>

--- a/components/templates/MatchAnnouncementTemplate.tsx
+++ b/components/templates/MatchAnnouncementTemplate.tsx
@@ -1,5 +1,6 @@
+import { MapPin } from 'lucide-react';
 import { MatchAnnouncementData } from '@/types';
-import RuntimeLogo from './RuntimeLogo';
+import RuntimeLogo from './RuntimeLogo'; // hero matchup에서 사용
 import { TemplateCanvas } from './shared/TemplateCanvas';
 import { SpeedLinesBg } from './shared/SpeedLinesBg';
 import { VignetteOverlay } from './shared/VignetteOverlay';
@@ -9,7 +10,7 @@ interface Props {
   data: MatchAnnouncementData;
 }
 
-const VIGNETTE_GRADIENT = 'radial-gradient(ellipse 70% 70% at 50% 55%, rgba(0,0,0,0.92) 30%, transparent 100%)';
+const VIGNETTE_GRADIENT = 'radial-gradient(ellipse 90% 90% at 50% 45%, rgba(0,0,0,0.6) 10%, rgba(0,0,0,0.2) 65%, transparent 100%)';
 
 const styles = {
   content: {
@@ -19,145 +20,131 @@ const styles = {
     height: '100%',
     display: 'flex',
     flexDirection: 'column' as const,
+    justifyContent: 'center',
     alignItems: 'center',
-    padding: '60px 80px 55px',
+    padding: '64px 72px 72px',
   },
-  logoSection: {
+
+  // ── Competition header ────────────────────────────────────
+  competitionHeader: {
+    flexShrink: 0,
     display: 'flex',
     flexDirection: 'column' as const,
     alignItems: 'center',
-    marginBottom: '32px',
-  },
-  logoAccentLine: {
-    width: '90px',
-    height: '3px',
-    background: 'linear-gradient(90deg, transparent, #CC0000, transparent)',
-    marginTop: '10px',
-  },
-  badge: {
-    background: 'rgba(204, 0, 0, 0.15)',
-    border: '1.5px solid #CC0000',
-    color: '#FF3333',
-    fontFamily: "'Bebas Neue', sans-serif",
-    fontSize: '22px',
-    letterSpacing: '4px',
-    padding: '6px 24px',
-    marginBottom: '18px',
-    clipPath: 'polygon(8px 0%, 100% 0%, calc(100% - 8px) 100%, 0% 100%)',
-  },
-  infoLine: {
-    fontFamily: "'Noto Sans KR', sans-serif",
-    fontSize: '22px',
-    fontWeight: 400,
-    color: 'rgba(255,255,255,0.75)',
-    letterSpacing: '1px',
-    marginBottom: '44px',
-  },
-  infoDate: {
-    color: '#fff',
-    fontWeight: 700,
-  },
-  divider: {
+    gap: '14px',
+    marginBottom: '120px',
     width: '100%',
-    height: '1px',
-    background: 'linear-gradient(90deg, transparent, rgba(204,0,0,0.6) 30%, rgba(204,0,0,0.6) 70%, transparent)',
-    marginBottom: '44px',
   },
-  sectionLabel: {
+  competitionText: {
     fontFamily: "'Bebas Neue', sans-serif",
-    fontSize: '26px',
-    letterSpacing: '6px',
-    color: 'rgba(255,255,255,0.5)',
-    marginBottom: '32px',
+    fontSize: '32px',
+    letterSpacing: '10px',
+    color: '#fff',
+    lineHeight: 1,
   },
-  matchupRow: {
+  competitionSub: {
+    fontFamily: "'Noto Sans KR', sans-serif",
+    fontSize: '24px',
+    fontWeight: 600,
+    letterSpacing: '6px',
+    lineHeight: 1,
+    marginTop: '2px',
+    background: 'linear-gradient(90deg, #CC0000, rgba(255,220,200,0.9), #CC0000)',
+    WebkitBackgroundClip: 'text' as const,
+    WebkitTextFillColor: 'transparent' as const,
+  },
+  competitionLine: {
+    width: '100%',
+    height: '2px',
+    background: 'linear-gradient(90deg, transparent, #CC0000 30%, #CC0000 70%, transparent)',
+  },
+
+  // ── Hero (matchup) ────────────────────────────────────────
+  hero: {
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'center',
-    gap: '50px',
-    width: '100%',
-    marginBottom: '50px',
-  },
-  teamCol: {
-    display: 'flex',
-    flexDirection: 'column' as const,
-    alignItems: 'center',
-    gap: '18px',
-    flex: 1,
-  },
-  teamName: {
-    fontFamily: "'Bebas Neue', sans-serif",
-    fontSize: '26px',
-    letterSpacing: '5px',
-    color: 'rgba(255,255,255,0.85)',
-  },
-  vsCol: {
-    display: 'flex',
-    flexDirection: 'column' as const,
-    alignItems: 'center',
-    gap: '16px',
     flexShrink: 0,
+    marginTop: '32px',
+    gap: '100px',
+  },
+  teamBlock: {
+    flex: 1,
+    display: 'flex',
+    flexDirection: 'column' as const,
+    width: '100px',
+    alignItems: 'center',
+    gap: '20px',
+  },
+  teamLabel: {
+    fontFamily: "'Bebas Neue', sans-serif",
+    fontSize: '36px',
+    letterSpacing: '8px',
+    color: 'rgba(255,255,255,0.85)',
+    lineHeight: 1,
+  },
+  opponentEmblem: {
+    width: '210px',
+    height: '210px',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  vsBlock: {
+    width: '200px',
+    flexShrink: 0,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
   },
   vsText: {
     fontFamily: "'Bebas Neue', sans-serif",
-    fontSize: '100px',
+    fontSize: '180px',
     color: '#CC0000',
     lineHeight: 1,
-    letterSpacing: '-2px',
-    textShadow: '0 0 40px rgba(204,0,0,0.6), 0 0 80px rgba(204,0,0,0.3)',
+    letterSpacing: '-4px',
+    textShadow: '0 0 50px rgba(204,0,0,0.7), 0 0 100px rgba(204,0,0,0.3)',
   },
-  opponentEmblem: {
-    width: '160px',
-    height: '160px',
-    border: '3px solid rgba(255,255,255,0.15)',
-    background: 'rgba(10,10,10,0.8)',
+
+  // ── Big date/time block ───────────────────────────────────
+  dateTimeBlock: {
+    flexShrink: 0,
     display: 'flex',
     flexDirection: 'column' as const,
+    alignItems: 'center',
+    gap: '8px',
+    marginTop: '64px',
+  },
+  bigDate: {
+    fontFamily: "'Bebas Neue', sans-serif",
+    fontSize: '72px',
+    color: 'rgba(255,255,255,0.8)',
+    letterSpacing: '4px',
+    lineHeight: 1,
+  },
+  bigTime: {
+    fontFamily: "'Bebas Neue', sans-serif",
+    fontSize: '44px',
+    color: 'rgba(255,255,255,0.4)',
+    letterSpacing: '6px',
+    lineHeight: 1,
+  },
+
+  // ── Venue (near bottom bar) ───────────────────────────────
+  venueRow: {
+    flexShrink: 0,
+    display: 'flex',
     alignItems: 'center',
     justifyContent: 'center',
-    clipPath: 'polygon(12px 0%, 100% 0%, calc(100% - 12px) 100%, 0% 100%)',
+    gap: '10px',
+    marginTop: '80px',
   },
-  timeBlock: {
-    background: 'rgba(204, 0, 0, 0.08)',
-    border: '1px solid rgba(204,0,0,0.4)',
-    padding: '22px 80px',
-    display: 'flex',
-    alignItems: 'center',
-    gap: '50px',
-    clipPath: 'polygon(14px 0%, 100% 0%, calc(100% - 14px) 100%, 0% 100%)',
-  },
-  timeBlockItem: {
-    display: 'flex',
-    flexDirection: 'column' as const,
-    alignItems: 'center',
-    gap: '4px',
-  },
-  timeBlockLabel: {
-    fontFamily: "'Bebas Neue', sans-serif",
-    fontSize: '18px',
-    letterSpacing: '4px',
-    color: '#CC0000',
-  },
-  timeBlockValue: {
-    fontFamily: "'Bebas Neue', sans-serif",
-    fontSize: '40px',
-    color: '#fff',
-    letterSpacing: '3px',
-    lineHeight: 1,
-  },
-  timeBlockVenueValue: {
-    fontSize: '40px',
-    fontFamily: "'Bebas Neue', sans-serif",
+  venueText: {
+    fontFamily: "'Noto Sans KR', sans-serif",
+    fontSize: '28px',
     fontWeight: 600,
-    letterSpacing: '1px',
-    color: '#fff',
-    lineHeight: 1,
-    whiteSpace: 'nowrap' as const,
-  },
-  timeBlockDivider: {
-    width: '1px',
-    height: '50px',
-    background: 'rgba(204,0,0,0.3)',
+    letterSpacing: '3px',
+    color: 'rgba(255,255,255,0.65)',
   },
 };
 
@@ -167,57 +154,39 @@ export default function MatchAnnouncementTemplate({ data }: Props) {
       <SpeedLinesBg filterId="blur-match-ann" />
       <VignetteOverlay gradient={VIGNETTE_GRADIENT} />
 
-      {/* Content */}
       <div style={styles.content}>
 
-        {/* Logo */}
-        <div style={styles.logoSection}>
-          <RuntimeLogo
-            width={108}
-            height={123}
-            color="white"
-            style={{ filter: 'drop-shadow(0 0 16px rgba(255,255,255,0.15))' }}
-          />
-          <div style={styles.logoAccentLine} />
+        {/* Competition header */}
+        <div style={styles.competitionHeader}>
+          <div style={styles.competitionLine} />
+          <div style={styles.competitionText}>{data.badge}</div>
+          {data.competition && (
+            <div style={styles.competitionSub}>{data.competition}</div>
+          )}
+          <div style={styles.competitionLine} />
         </div>
 
-        {/* Badge */}
-        <div style={styles.badge}>{data.badge}</div>
-
-        {/* Info line */}
-        <div style={styles.infoLine}>
-          <span style={styles.infoDate}>{data.infoDate}</span>
-          &nbsp;&nbsp;/&nbsp;&nbsp;
-          {data.infoVenue}
-        </div>
-
-        {/* Divider */}
-        <div style={styles.divider} />
-
-        {/* Section label */}
-        <div style={styles.sectionLabel}>[ MATCHUP ]</div>
-
-        {/* Matchup */}
-        <div style={styles.matchupRow}>
+        {/* Hero: team matchup */}
+        <div style={styles.hero}>
 
           {/* RUNTIME */}
-          <div style={styles.teamCol}>
+          <div style={styles.teamBlock}>
             <RuntimeLogo
-              width={158}
-              height={180}
+              width={200}
+              height={228}
               color="white"
-              style={{ filter: 'drop-shadow(0 0 14px rgba(204,0,0,0.35)) drop-shadow(0 0 30px rgba(255,255,255,0.08))' }}
+              style={{ filter: 'drop-shadow(0 0 16px rgba(204,0,0,0.4)) drop-shadow(0 0 32px rgba(255,255,255,0.06))' }}
             />
-            <div style={styles.teamName}>RUNTIME</div>
+            <div style={styles.teamLabel}>RUNTIME</div>
           </div>
 
           {/* VS */}
-          <div style={styles.vsCol}>
+          <div style={styles.vsBlock}>
             <div style={styles.vsText}>VS</div>
           </div>
 
           {/* Opponent */}
-          <div style={styles.teamCol}>
+          <div style={styles.teamBlock}>
             <div style={styles.opponentEmblem}>
               {data.opponentImage ? (
                 // eslint-disable-next-line @next/next/no-img-element
@@ -227,7 +196,7 @@ export default function MatchAnnouncementTemplate({ data }: Props) {
                   style={{ width: '100%', height: '100%', objectFit: 'contain' }}
                 />
               ) : (
-                <svg viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg" width="90" height="90" style={{ opacity: 0.5 }}>
+                <svg viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg" width="210" height="210" style={{ opacity: 0.45 }}>
                   <path d="M50 8 L88 22 L88 52 C88 72 70 88 50 94 C30 88 12 72 12 52 L12 22 Z"
                     fill="rgba(255,255,255,0.05)" stroke="rgba(255,255,255,0.35)" strokeWidth="2.5" />
                   <path d="M50 18 L80 29 L80 52 C80 67 66 80 50 85 C34 80 20 67 20 52 L20 29 Z"
@@ -235,27 +204,22 @@ export default function MatchAnnouncementTemplate({ data }: Props) {
                 </svg>
               )}
             </div>
-            <div style={styles.teamName}>{data.awayTeam}</div>
+            <div style={styles.teamLabel}>{data.awayTeam}</div>
           </div>
         </div>
 
-        {/* Time block */}
-        <div style={styles.timeBlock}>
-          <div style={styles.timeBlockItem}>
-            <div style={styles.timeBlockLabel}>DATE</div>
-            <div style={styles.timeBlockValue}>{data.matchDate}</div>
-          </div>
-          <div style={styles.timeBlockDivider} />
-          <div style={styles.timeBlockItem}>
-            <div style={styles.timeBlockLabel}>KICKOFF</div>
-            <div style={styles.timeBlockValue}>{data.kickoffTime}</div>
-          </div>
-          <div style={styles.timeBlockDivider} />
-          <div style={styles.timeBlockItem}>
-            <div style={styles.timeBlockLabel}>VENUE</div>
-            <div style={styles.timeBlockVenueValue}>{data.venueShort}</div>
-          </div>
+        {/* Big date + time */}
+        <div style={styles.dateTimeBlock}>
+          <div style={styles.bigDate}>{data.matchDate}</div>
+          <div style={styles.bigTime}>{data.kickoffTime}</div>
         </div>
+
+        {/* Venue near bottom */}
+        <div style={styles.venueRow}>
+          <MapPin size={22} color="rgba(204,0,0,0.8)" strokeWidth={2.5} />
+          <div style={styles.venueText}>{data.venueShort}</div>
+        </div>
+
       </div>
 
       <BottomBar />

--- a/types/index.ts
+++ b/types/index.ts
@@ -10,6 +10,7 @@ export interface SubPlayer {
 
 export interface MatchAnnouncementData {
   badge: string;
+  competition: string;
   infoDate: string;
   infoVenue: string;
   awayTeam: string;


### PR DESCRIPTION
Closes #5

## Summary
- 팀 블록 사이 gap 100px 추가, 런타임/상대팀 로고 크기 확대
- MATCH PREVIEW 하단에 `competition` 서브텍스트 추가 (레드-웜화이트 그라디언트)
- `venueShort` 폼 입력 필드 추가
- venue 양쪽 선 제거 → `lucide-react` MapPin 아이콘으로 교체

## Test plan
- [ ] Match Announcement 탭에서 각 필드 입력 후 미리보기 확인
- [ ] 상대팀 엠블럼 업로드/미업로드 시 레이아웃 확인
- [ ] competition 필드 비워뒀을 때 서브텍스트 미표시 확인