### PR TITLE
fix: 모바일 이미지 업로드 및 다운로드 버그 수정 (#9)

### DIFF
--- a/components/DownloadButton.tsx
+++ b/components/DownloadButton.tsx
@@ -29,16 +29,35 @@ export default function DownloadButton({ targetId, filename = 'runtime-card' }: 
 
       await new Promise<void>((r) => requestAnimationFrame(() => requestAnimationFrame(() => r())));
 
-      const { toPng } = await import('html-to-image');
-      const dataUrl = await toPng(element, {
-        width: 1080,
-        height: 1080,
-        pixelRatio: 1,
-      });
+      const isMobile = /iPhone|iPad|iPod|Android/i.test(navigator.userAgent);
+
+      let dataUrl: string;
+      if (isMobile) {
+        // iOS Safari는 html-to-image의 SVG foreignObject 방식이 불안정함
+        // html2canvas는 직접 캔버스에 그려 모바일에서 더 안정적
+        const html2canvas = (await import('html2canvas')).default;
+        const canvas = await html2canvas(element, {
+          width: 1080,
+          height: 1080,
+          scale: 1,
+          useCORS: true,
+          allowTaint: true,
+          backgroundColor: '#080808',
+          windowWidth: 1080,
+          windowHeight: 1080,
+        });
+        dataUrl = canvas.toDataURL('image/png');
+      } else {
+        const { toPng } = await import('html-to-image');
+        dataUrl = await toPng(element, {
+          width: 1080,
+          height: 1080,
+          pixelRatio: 1,
+        });
+      }
 
       // 위치 복원
       element.style.cssText = prevCssText;
-      const isMobile = /iPhone|iPad|iPod|Android/i.test(navigator.userAgent);
 
       if (isMobile) {
         if (navigator.share) {

--- a/components/ImageCropModal.tsx
+++ b/components/ImageCropModal.tsx
@@ -58,18 +58,26 @@ export default function ImageCropModal({ src, aspectRatio, label, onConfirm, onC
     if (!img || !disp) return;
     const scaleX = img.naturalWidth / disp.w;
     const scaleY = img.naturalHeight / disp.h;
-    const cw = Math.round(cropDim.w * scaleX);
-    const ch = Math.round(cropDim.h * scaleY);
+    const srcX = Math.round(cropPos.x * scaleX);
+    const srcY = Math.round(cropPos.y * scaleY);
+    const srcW = Math.round(cropDim.w * scaleX);
+    const srcH = Math.round(cropDim.h * scaleY);
+
+    // iOS Safari는 캔버스 크기가 너무 크면 drawImage가 조용히 실패함
+    const MAX = 2048;
+    let dstW = srcW, dstH = srcH;
+    if (dstW > MAX || dstH > MAX) {
+      const ratio = Math.min(MAX / dstW, MAX / dstH);
+      dstW = Math.round(dstW * ratio);
+      dstH = Math.round(dstH * ratio);
+    }
+
     const canvas = document.createElement('canvas');
-    canvas.width = cw;
-    canvas.height = ch;
-    const ctx = canvas.getContext('2d')!;
-    ctx.drawImage(
-      img,
-      Math.round(cropPos.x * scaleX), Math.round(cropPos.y * scaleY),
-      cw, ch,
-      0, 0, cw, ch,
-    );
+    canvas.width = dstW;
+    canvas.height = dstH;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+    ctx.drawImage(img, srcX, srcY, srcW, srcH, 0, 0, dstW, dstH);
     onConfirm(canvas.toDataURL('image/jpeg', 0.92));
   };
 


### PR DESCRIPTION
## Summary

- `ImageCropModal`: 크롭 시 출력 캔버스를 최대 2048px로 제한 — iOS Safari에서 고해상도 카메라 사진(12MP+) 처리 시 `drawImage`가 조용히 실패하던 문제 해결
- `DownloadButton`: 모바일에서 `html-to-image` 대신 `html2canvas` 사용 — SVG foreignObject 불안정으로 인한 폰트 깨짐 및 이미지 누락 해결

Closes #9

## Test plan

- [ ] iOS Safari에서 카메라 사진 업로드 후 미리보기에 이미지 정상 표시 확인
- [ ] 모바일에서 다운로드 시 텍스트(한글 포함) 정상 렌더링 확인
- [ ] 모바일에서 다운로드 이미지에 업로드한 사진 정상 포함 확인
- [ ] 데스크톱에서 기존 동작 이상 없음 확인