### PR TITLE
fix: 템플릿 팀명 줄바꿈 및 GOALS 섹션 정렬 개선 (#11)

### DIFF
--- a/components/DownloadButton.tsx
+++ b/components/DownloadButton.tsx
@@ -7,6 +7,72 @@ interface Props {
   filename?: string;
 }
 
+/**
+ * iOS Safari는 SVG foreignObject 내부에서 CSS filter / WebkitBackgroundClip: text를
+ * 렌더링하지 않음. 캡처 전 해당 속성을 직접 처리하고 캡처 후 복원한다.
+ */
+async function applyMobileFixes(root: HTMLElement): Promise<() => void> {
+  const restores: (() => void)[] = [];
+
+  // Fix 1: CSS filter가 걸린 img → canvas로 필터 적용 후 data URL로 교체
+  const filteredImgs = root.querySelectorAll<HTMLImageElement>('img');
+  for (const img of filteredImgs) {
+    const filterVal = img.style.filter;
+    if (!filterVal) continue;
+
+    // 이미지 로드 보장
+    if (!img.complete) {
+      await new Promise<void>((resolve) => {
+        img.onload = () => resolve();
+        img.onerror = () => resolve();
+      });
+    }
+
+    const w = img.naturalWidth || img.width;
+    const h = img.naturalHeight || img.height;
+    if (!w || !h) continue;
+
+    const canvas = document.createElement('canvas');
+    canvas.width = w;
+    canvas.height = h;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) continue;
+
+    ctx.filter = filterVal;
+    ctx.drawImage(img, 0, 0, w, h);
+    const dataUrl = canvas.toDataURL();
+
+    const prevSrc = img.src;
+    const prevFilter = img.style.filter;
+    img.src = dataUrl;
+    img.style.filter = '';
+    restores.push(() => {
+      img.src = prevSrc;
+      img.style.filter = prevFilter;
+    });
+  }
+
+  // Fix 2: WebkitTextFillColor: transparent (그라디언트 클립 텍스트) → 단색 처리
+  const allEls = root.querySelectorAll<HTMLElement>('*');
+  for (const el of allEls) {
+    if (el.style.WebkitTextFillColor === 'transparent') {
+      const prevFill = el.style.WebkitTextFillColor;
+      const prevClip = el.style.WebkitBackgroundClip;
+      el.style.WebkitTextFillColor = '#CC0000';
+      el.style.WebkitBackgroundClip = 'unset';
+      restores.push(() => {
+        el.style.WebkitTextFillColor = prevFill;
+        el.style.WebkitBackgroundClip = prevClip;
+      });
+    }
+  }
+
+  // DOM 반영 대기
+  await new Promise<void>((r) => requestAnimationFrame(() => r()));
+
+  return () => restores.forEach((fn) => fn());
+}
+
 export default function DownloadButton({ targetId, filename = 'runtime-card' }: Props) {
   const [loading, setLoading] = useState(false);
 
@@ -19,6 +85,8 @@ export default function DownloadButton({ targetId, filename = 'runtime-card' }: 
       'position:fixed;inset:0;background:#0a0a0a;z-index:9999;pointer-events:none;';
     document.body.appendChild(overlay);
 
+    let restore: (() => void) | undefined;
+
     try {
       const element = document.getElementById(targetId);
       if (!element) return;
@@ -29,6 +97,12 @@ export default function DownloadButton({ targetId, filename = 'runtime-card' }: 
 
       await new Promise<void>((r) => requestAnimationFrame(() => requestAnimationFrame(() => r())));
 
+      const isMobile = /iPhone|iPad|iPod|Android/i.test(navigator.userAgent);
+
+      if (isMobile) {
+        restore = await applyMobileFixes(element);
+      }
+
       const { toPng } = await import('html-to-image');
       const dataUrl = await toPng(element, {
         width: 1080,
@@ -36,9 +110,11 @@ export default function DownloadButton({ targetId, filename = 'runtime-card' }: 
         pixelRatio: 1,
       });
 
+      restore?.();
+      restore = undefined;
+
       // 위치 복원
       element.style.cssText = prevCssText;
-      const isMobile = /iPhone|iPad|iPod|Android/i.test(navigator.userAgent);
 
       if (isMobile) {
         if (navigator.share) {
@@ -63,6 +139,7 @@ export default function DownloadButton({ targetId, filename = 'runtime-card' }: 
         link.click();
       }
     } finally {
+      restore?.();
       overlay.remove();
       setLoading(false);
     }

--- a/components/DownloadButton.tsx
+++ b/components/DownloadButton.tsx
@@ -29,35 +29,16 @@ export default function DownloadButton({ targetId, filename = 'runtime-card' }: 
 
       await new Promise<void>((r) => requestAnimationFrame(() => requestAnimationFrame(() => r())));
 
-      const isMobile = /iPhone|iPad|iPod|Android/i.test(navigator.userAgent);
-
-      let dataUrl: string;
-      if (isMobile) {
-        // iOS Safari는 html-to-image의 SVG foreignObject 방식이 불안정함
-        // html2canvas는 직접 캔버스에 그려 모바일에서 더 안정적
-        const html2canvas = (await import('html2canvas')).default;
-        const canvas = await html2canvas(element, {
-          width: 1080,
-          height: 1080,
-          scale: 1,
-          useCORS: true,
-          allowTaint: true,
-          backgroundColor: '#080808',
-          windowWidth: 1080,
-          windowHeight: 1080,
-        });
-        dataUrl = canvas.toDataURL('image/png');
-      } else {
-        const { toPng } = await import('html-to-image');
-        dataUrl = await toPng(element, {
-          width: 1080,
-          height: 1080,
-          pixelRatio: 1,
-        });
-      }
+      const { toPng } = await import('html-to-image');
+      const dataUrl = await toPng(element, {
+        width: 1080,
+        height: 1080,
+        pixelRatio: 1,
+      });
 
       // 위치 복원
       element.style.cssText = prevCssText;
+      const isMobile = /iPhone|iPad|iPod|Android/i.test(navigator.userAgent);
 
       if (isMobile) {
         if (navigator.share) {

--- a/components/DownloadButton.tsx
+++ b/components/DownloadButton.tsx
@@ -15,14 +15,12 @@ async function applyMobileFixes(root: HTMLElement): Promise<() => void> {
   const restores: (() => void)[] = [];
 
   // Fix 1: CSS filter(invert)가 걸린 img → 픽셀 조작으로 흰색 변환
-  // ctx.filter는 iOS에서 SVG에 불안정 → SVG 내부 PNG를 추출해 직접 처리
   const imgs = root.querySelectorAll<HTMLImageElement>('img');
   for (const img of imgs) {
     const filterVal = img.style.filter;
     if (!filterVal || !filterVal.includes('invert')) continue;
 
     try {
-      // SVG URL이면 내장된 PNG를 꺼내 처리 (canvas taint 방지)
       let srcToDraw = img.src;
       if (!img.src.startsWith('data:')) {
         const resp = await fetch(img.src);
@@ -32,14 +30,16 @@ async function applyMobileFixes(root: HTMLElement): Promise<() => void> {
       }
 
       const tempImg = new Image();
-      tempImg.src = srcToDraw;
       await new Promise<void>((r) => {
         tempImg.onload = () => r();
         tempImg.onerror = () => r();
+        tempImg.src = srcToDraw;
+        // data URL은 동기적으로 로드될 수 있음
+        if (tempImg.complete && tempImg.naturalWidth) r();
       });
 
-      const w = tempImg.naturalWidth || img.naturalWidth || img.width;
-      const h = tempImg.naturalHeight || img.naturalHeight || img.height;
+      const w = tempImg.naturalWidth || img.naturalWidth || img.offsetWidth;
+      const h = tempImg.naturalHeight || img.naturalHeight || img.offsetHeight;
       if (!w || !h) continue;
 
       const canvas = document.createElement('canvas');
@@ -49,8 +49,6 @@ async function applyMobileFixes(root: HTMLElement): Promise<() => void> {
       if (!ctx) continue;
 
       ctx.drawImage(tempImg, 0, 0, w, h);
-
-      // brightness(0) invert(1): 불투명 픽셀을 모두 흰색으로
       const imageData = ctx.getImageData(0, 0, w, h);
       const data = imageData.data;
       for (let i = 0; i < data.length; i += 4) {
@@ -61,12 +59,25 @@ async function applyMobileFixes(root: HTMLElement): Promise<() => void> {
         }
       }
       ctx.putImageData(imageData, 0, 0);
-
       const whiteDataUrl = canvas.toDataURL('image/png');
+
       const prevSrc = img.src;
       const prevFilter = img.style.filter;
-      img.src = whiteDataUrl;
       img.style.filter = '';
+      img.src = whiteDataUrl;
+
+      // 새 이미지(data URL)가 완전히 로드될 때까지 대기
+      await new Promise<void>((r) => {
+        if (img.complete && img.naturalWidth) { r(); return; }
+        const done = () => {
+          img.removeEventListener('load', done);
+          img.removeEventListener('error', done);
+          r();
+        };
+        img.addEventListener('load', done);
+        img.addEventListener('error', done);
+      });
+
       restores.push(() => {
         img.src = prevSrc;
         img.style.filter = prevFilter;
@@ -77,23 +88,23 @@ async function applyMobileFixes(root: HTMLElement): Promise<() => void> {
   }
 
   // Fix 2: gradient clip text → webkit 속성 제거 (흰색 inherited color로 표시)
-  // React는 style.setProperty('-webkit-text-fill-color', ...)로 설정하므로
-  // cssText로 감지해야 함 (el.style.WebkitTextFillColor 접근은 불안정)
+  // getPropertyValue()로 감지 (cssText.includes보다 신뢰성 높음)
   const allEls = root.querySelectorAll<HTMLElement>('*');
   for (const el of allEls) {
-    if (!el.style.cssText.includes('-webkit-text-fill-color')) continue;
+    const textFillColor = el.style.getPropertyValue('-webkit-text-fill-color');
+    if (!textFillColor) continue;
 
     const prevCssText = el.style.cssText;
     el.style.removeProperty('-webkit-text-fill-color');
     el.style.removeProperty('-webkit-background-clip');
-    el.style.removeProperty('background');
+    el.style.background = 'none';
     restores.push(() => {
       el.style.cssText = prevCssText;
     });
   }
 
   // DOM 반영 대기
-  await new Promise<void>((r) => requestAnimationFrame(() => r()));
+  await new Promise<void>((r) => requestAnimationFrame(() => requestAnimationFrame(() => r())));
 
   return () => restores.forEach((fn) => fn());
 }

--- a/components/DownloadButton.tsx
+++ b/components/DownloadButton.tsx
@@ -8,63 +8,88 @@ interface Props {
 }
 
 /**
- * iOS Safari는 SVG foreignObject 내부에서 CSS filter / WebkitBackgroundClip: text를
+ * iOS Safari는 SVG foreignObject 내부에서 CSS filter / -webkit-text-fill-color를
  * 렌더링하지 않음. 캡처 전 해당 속성을 직접 처리하고 캡처 후 복원한다.
  */
 async function applyMobileFixes(root: HTMLElement): Promise<() => void> {
   const restores: (() => void)[] = [];
 
-  // Fix 1: CSS filter가 걸린 img → canvas로 필터 적용 후 data URL로 교체
-  const filteredImgs = root.querySelectorAll<HTMLImageElement>('img');
-  for (const img of filteredImgs) {
+  // Fix 1: CSS filter(invert)가 걸린 img → 픽셀 조작으로 흰색 변환
+  // ctx.filter는 iOS에서 SVG에 불안정 → SVG 내부 PNG를 추출해 직접 처리
+  const imgs = root.querySelectorAll<HTMLImageElement>('img');
+  for (const img of imgs) {
     const filterVal = img.style.filter;
-    if (!filterVal) continue;
+    if (!filterVal || !filterVal.includes('invert')) continue;
 
-    // 이미지 로드 보장
-    if (!img.complete) {
-      await new Promise<void>((resolve) => {
-        img.onload = () => resolve();
-        img.onerror = () => resolve();
+    try {
+      // SVG URL이면 내장된 PNG를 꺼내 처리 (canvas taint 방지)
+      let srcToDraw = img.src;
+      if (!img.src.startsWith('data:')) {
+        const resp = await fetch(img.src);
+        const svgText = await resp.text();
+        const match = svgText.match(/xlink:href="(data:image\/[^"]+)"/);
+        if (match) srcToDraw = match[1];
+      }
+
+      const tempImg = new Image();
+      tempImg.src = srcToDraw;
+      await new Promise<void>((r) => {
+        tempImg.onload = () => r();
+        tempImg.onerror = () => r();
       });
+
+      const w = tempImg.naturalWidth || img.naturalWidth || img.width;
+      const h = tempImg.naturalHeight || img.naturalHeight || img.height;
+      if (!w || !h) continue;
+
+      const canvas = document.createElement('canvas');
+      canvas.width = w;
+      canvas.height = h;
+      const ctx = canvas.getContext('2d');
+      if (!ctx) continue;
+
+      ctx.drawImage(tempImg, 0, 0, w, h);
+
+      // brightness(0) invert(1): 불투명 픽셀을 모두 흰색으로
+      const imageData = ctx.getImageData(0, 0, w, h);
+      const data = imageData.data;
+      for (let i = 0; i < data.length; i += 4) {
+        if (data[i + 3] > 10) {
+          data[i] = 255;
+          data[i + 1] = 255;
+          data[i + 2] = 255;
+        }
+      }
+      ctx.putImageData(imageData, 0, 0);
+
+      const whiteDataUrl = canvas.toDataURL('image/png');
+      const prevSrc = img.src;
+      const prevFilter = img.style.filter;
+      img.src = whiteDataUrl;
+      img.style.filter = '';
+      restores.push(() => {
+        img.src = prevSrc;
+        img.style.filter = prevFilter;
+      });
+    } catch {
+      // 변환 실패 시 원본 유지
     }
-
-    const w = img.naturalWidth || img.width;
-    const h = img.naturalHeight || img.height;
-    if (!w || !h) continue;
-
-    const canvas = document.createElement('canvas');
-    canvas.width = w;
-    canvas.height = h;
-    const ctx = canvas.getContext('2d');
-    if (!ctx) continue;
-
-    ctx.filter = filterVal;
-    ctx.drawImage(img, 0, 0, w, h);
-    const dataUrl = canvas.toDataURL();
-
-    const prevSrc = img.src;
-    const prevFilter = img.style.filter;
-    img.src = dataUrl;
-    img.style.filter = '';
-    restores.push(() => {
-      img.src = prevSrc;
-      img.style.filter = prevFilter;
-    });
   }
 
-  // Fix 2: WebkitTextFillColor: transparent (그라디언트 클립 텍스트) → 단색 처리
+  // Fix 2: gradient clip text → webkit 속성 제거 (흰색 inherited color로 표시)
+  // React는 style.setProperty('-webkit-text-fill-color', ...)로 설정하므로
+  // cssText로 감지해야 함 (el.style.WebkitTextFillColor 접근은 불안정)
   const allEls = root.querySelectorAll<HTMLElement>('*');
   for (const el of allEls) {
-    if (el.style.WebkitTextFillColor === 'transparent') {
-      const prevFill = el.style.WebkitTextFillColor;
-      const prevClip = el.style.WebkitBackgroundClip;
-      el.style.WebkitTextFillColor = '#CC0000';
-      el.style.WebkitBackgroundClip = 'unset';
-      restores.push(() => {
-        el.style.WebkitTextFillColor = prevFill;
-        el.style.WebkitBackgroundClip = prevClip;
-      });
-    }
+    if (!el.style.cssText.includes('-webkit-text-fill-color')) continue;
+
+    const prevCssText = el.style.cssText;
+    el.style.removeProperty('-webkit-text-fill-color');
+    el.style.removeProperty('-webkit-background-clip');
+    el.style.removeProperty('background');
+    restores.push(() => {
+      el.style.cssText = prevCssText;
+    });
   }
 
   // DOM 반영 대기

--- a/components/DownloadButton.tsx
+++ b/components/DownloadButton.tsx
@@ -7,137 +7,67 @@ interface Props {
   filename?: string;
 }
 
-/**
- * iOS Safari는 SVG foreignObject 내부에서 CSS filter / -webkit-text-fill-color를
- * 렌더링하지 않음. 캡처 전 해당 속성을 직접 처리하고 캡처 후 복원한다.
- */
-async function applyMobileFixes(root: HTMLElement): Promise<() => void> {
-  const restores: (() => void)[] = [];
+function showMobileScreenshotMode(element: HTMLElement): () => void {
+  const prevCssText = element.style.cssText;
+  const scale = window.innerWidth / 1080;
+  const cardDisplayHeight = Math.round(1080 * scale);
 
-  // Fix 1: CSS filter(invert)가 걸린 img → 픽셀 조작으로 흰색 변환
-  const imgs = root.querySelectorAll<HTMLImageElement>('img');
-  for (const img of imgs) {
-    const filterVal = img.style.filter;
-    if (!filterVal || !filterVal.includes('invert')) continue;
+  // 전체 화면 덮개
+  const backdrop = document.createElement('div');
+  backdrop.style.cssText =
+    'position:fixed;inset:0;background:#0a0a0a;z-index:9996;';
+  document.body.appendChild(backdrop);
 
-    try {
-      let srcToDraw = img.src;
-      if (!img.src.startsWith('data:')) {
-        const resp = await fetch(img.src);
-        const svgText = await resp.text();
-        const match = svgText.match(/xlink:href="(data:image\/[^"]+)"/);
-        if (match) srcToDraw = match[1];
-      }
+  // 카드를 화면 상단에 꽉 차게 배치
+  element.style.cssText = `position:fixed;top:0;left:0;width:1080px;height:1080px;transform:scale(${scale});transform-origin:top left;z-index:9997;overflow:hidden;pointer-events:none;`;
 
-      const tempImg = new Image();
-      await new Promise<void>((r) => {
-        tempImg.onload = () => r();
-        tempImg.onerror = () => r();
-        tempImg.src = srcToDraw;
-        // data URL은 동기적으로 로드될 수 있음
-        if (tempImg.complete && tempImg.naturalWidth) r();
-      });
+  // 하단 안내 바
+  const bar = document.createElement('div');
+  bar.style.cssText = `position:fixed;top:${cardDisplayHeight}px;left:0;right:0;bottom:0;background:#0a0a0a;z-index:9998;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:16px;`;
+  bar.innerHTML = `
+    <div style="font-family:'Bebas Neue',sans-serif;font-size:15px;letter-spacing:4px;color:rgba(255,255,255,0.45);">스크린샷을 찍어주세요</div>
+    <button id="sc-close-btn" style="font-family:'Bebas Neue',sans-serif;font-size:15px;letter-spacing:3px;padding:10px 32px;background:#CC0000;color:#fff;border:none;cursor:pointer;clip-path:polygon(8px 0%,100% 0%,calc(100% - 8px) 100%,0% 100%);">CLOSE</button>
+  `;
+  document.body.appendChild(bar);
 
-      const w = tempImg.naturalWidth || img.naturalWidth || img.offsetWidth;
-      const h = tempImg.naturalHeight || img.naturalHeight || img.offsetHeight;
-      if (!w || !h) continue;
+  const cleanup = () => {
+    element.style.cssText = prevCssText;
+    backdrop.remove();
+    bar.remove();
+  };
 
-      const canvas = document.createElement('canvas');
-      canvas.width = w;
-      canvas.height = h;
-      const ctx = canvas.getContext('2d');
-      if (!ctx) continue;
-
-      ctx.drawImage(tempImg, 0, 0, w, h);
-      const imageData = ctx.getImageData(0, 0, w, h);
-      const data = imageData.data;
-      for (let i = 0; i < data.length; i += 4) {
-        if (data[i + 3] > 10) {
-          data[i] = 255;
-          data[i + 1] = 255;
-          data[i + 2] = 255;
-        }
-      }
-      ctx.putImageData(imageData, 0, 0);
-      const whiteDataUrl = canvas.toDataURL('image/png');
-
-      const prevSrc = img.src;
-      const prevFilter = img.style.filter;
-      img.style.filter = '';
-      img.src = whiteDataUrl;
-
-      // 새 이미지(data URL)가 완전히 로드될 때까지 대기
-      await new Promise<void>((r) => {
-        if (img.complete && img.naturalWidth) { r(); return; }
-        const done = () => {
-          img.removeEventListener('load', done);
-          img.removeEventListener('error', done);
-          r();
-        };
-        img.addEventListener('load', done);
-        img.addEventListener('error', done);
-      });
-
-      restores.push(() => {
-        img.src = prevSrc;
-        img.style.filter = prevFilter;
-      });
-    } catch {
-      // 변환 실패 시 원본 유지
-    }
-  }
-
-  // Fix 2: gradient clip text → webkit 속성 제거 (흰색 inherited color로 표시)
-  // getPropertyValue()로 감지 (cssText.includes보다 신뢰성 높음)
-  const allEls = root.querySelectorAll<HTMLElement>('*');
-  for (const el of allEls) {
-    const textFillColor = el.style.getPropertyValue('-webkit-text-fill-color');
-    if (!textFillColor) continue;
-
-    const prevCssText = el.style.cssText;
-    el.style.removeProperty('-webkit-text-fill-color');
-    el.style.removeProperty('-webkit-background-clip');
-    el.style.background = 'none';
-    restores.push(() => {
-      el.style.cssText = prevCssText;
-    });
-  }
-
-  // DOM 반영 대기
-  await new Promise<void>((r) => requestAnimationFrame(() => requestAnimationFrame(() => r())));
-
-  return () => restores.forEach((fn) => fn());
+  document.getElementById('sc-close-btn')?.addEventListener('click', cleanup);
+  return cleanup;
 }
 
 export default function DownloadButton({ targetId, filename = 'runtime-card' }: Props) {
   const [loading, setLoading] = useState(false);
 
   const handleDownload = async () => {
+    const element = document.getElementById(targetId);
+    if (!element) return;
+
+    const isMobile = /iPhone|iPad|iPod|Android/i.test(navigator.userAgent);
+
+    if (isMobile) {
+      showMobileScreenshotMode(element);
+      return;
+    }
+
+    // 데스크톱: PNG 생성 후 다운로드
     setLoading(true);
 
-    // 캡처 중 카드가 화면에 잠깐 보이는 것을 막는 오버레이
     const overlay = document.createElement('div');
     overlay.style.cssText =
       'position:fixed;inset:0;background:#0a0a0a;z-index:9999;pointer-events:none;';
     document.body.appendChild(overlay);
 
-    let restore: (() => void) | undefined;
-
     try {
-      const element = document.getElementById(targetId);
-      if (!element) return;
-
       const prevCssText = element.style.cssText;
       element.style.cssText =
         'position:fixed;left:0;top:0;width:1080px;height:1080px;overflow:hidden;pointer-events:none;z-index:9998;';
 
       await new Promise<void>((r) => requestAnimationFrame(() => requestAnimationFrame(() => r())));
-
-      const isMobile = /iPhone|iPad|iPod|Android/i.test(navigator.userAgent);
-
-      if (isMobile) {
-        restore = await applyMobileFixes(element);
-      }
 
       const { toPng } = await import('html-to-image');
       const dataUrl = await toPng(element, {
@@ -146,36 +76,13 @@ export default function DownloadButton({ targetId, filename = 'runtime-card' }: 
         pixelRatio: 1,
       });
 
-      restore?.();
-      restore = undefined;
-
-      // 위치 복원
       element.style.cssText = prevCssText;
 
-      if (isMobile) {
-        if (navigator.share) {
-          const res = await fetch(dataUrl);
-          const blob = await res.blob();
-          const file = new File([blob], `${filename}.png`, { type: 'image/png' });
-          try {
-            await navigator.share({ files: [file] });
-            return;
-          } catch {
-            // 공유 취소 or 미지원 → 다운로드 fallback
-          }
-        }
-        const link = document.createElement('a');
-        link.download = `${filename}.png`;
-        link.href = dataUrl;
-        link.click();
-      } else {
-        const link = document.createElement('a');
-        link.download = `${filename}.png`;
-        link.href = dataUrl;
-        link.click();
-      }
+      const link = document.createElement('a');
+      link.download = `${filename}.png`;
+      link.href = dataUrl;
+      link.click();
     } finally {
-      restore?.();
       overlay.remove();
       setLoading(false);
     }

--- a/components/templates/MatchAnnouncementTemplate.tsx
+++ b/components/templates/MatchAnnouncementTemplate.tsx
@@ -86,6 +86,7 @@ const styles = {
     letterSpacing: "8px",
     color: "rgba(255,255,255,0.85)",
     lineHeight: 1,
+    whiteSpace: "nowrap",
   },
   opponentEmblem: {
     width: "210px",

--- a/components/templates/MatchResultFriendlyTemplate.tsx
+++ b/components/templates/MatchResultFriendlyTemplate.tsx
@@ -97,6 +97,7 @@ export default function MatchResultFriendlyTemplate({ data }: Props) {
             <div style={{
               fontFamily: "'Bebas Neue', sans-serif",
               fontSize: '24px', letterSpacing: '5px', color: 'rgba(255,255,255,0.85)',
+              whiteSpace: 'nowrap',
             }}>{data.awayTeam}</div>
           </div>
         </div>

--- a/components/templates/MatchResultOfficialTemplate.tsx
+++ b/components/templates/MatchResultOfficialTemplate.tsx
@@ -310,6 +310,7 @@ export default function MatchResultOfficialTemplate({ data }: Props) {
                 fontSize: '42px',
                 letterSpacing: '5px',
                 color: 'rgba(255,255,255,0.85)',
+                whiteSpace: 'nowrap',
               }}
             >
               {data.awayTeam}
@@ -369,14 +370,13 @@ export default function MatchResultOfficialTemplate({ data }: Props) {
               </div>
               <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
                 {data.scorers.map((s, i) => (
-                  <div key={i} style={{ display: 'flex', alignItems: 'flex-end' }}>
+                  <div key={i} style={{ display: 'flex', alignItems: 'center' }}>
                     <div
                       style={{
                         width: '36px',
                         flexShrink: 0,
                         display: 'flex',
-                        alignItems: 'flex-end',
-                        paddingBottom: '3px',
+                        alignItems: 'center',
                       }}
                     >
                       <SoccerBall size={22} />
@@ -386,12 +386,13 @@ export default function MatchResultOfficialTemplate({ data }: Props) {
                         width: '68px',
                         flexShrink: 0,
                         display: 'flex',
-                        alignItems: 'flex-end',
+                        alignItems: 'center',
                       }}
                     >
                       <span
                         style={{
                           fontFamily: "'Bebas Neue', sans-serif",
+                          marginTop: '4px',
                           fontSize: '38px',
                           lineHeight: 1,
                           color: 'rgba(204,0,0,0.9)',
@@ -406,20 +407,21 @@ export default function MatchResultOfficialTemplate({ data }: Props) {
                         width: '180px',
                         flexShrink: 0,
                         display: 'flex',
-                        alignItems: 'flex-end',
+                        alignItems: 'center',
                         gap: '6px',
                       }}
                     >
                       <span
                         style={{
+                          marginTop: '-2px',
                           fontFamily: "'Noto Sans KR', sans-serif",
-                          fontSize: '32px',
+                          fontSize: '28px',
                           fontWeight: 700,
-                          lineHeight: 1,
+                          lineHeight: 1.2,
                           color: 'rgba(255,255,255,0.95)',
                           letterSpacing: '4px',
                           display: 'inline-block',
-                          transform: 'scaleX(0.78)',
+                          transform: 'scaleX(0.92)',
                           transformOrigin: 'left center',
                         }}
                       >
@@ -447,8 +449,7 @@ export default function MatchResultOfficialTemplate({ data }: Props) {
                             width: '30px',
                             flexShrink: 0,
                             display: 'flex',
-                            alignItems: 'flex-end',
-                            paddingBottom: '3px',
+                            alignItems: 'center',
                           }}
                         >
                           <SportShoe size={20} color="rgba(255,255,255,0.3)" strokeWidth={1.5} />

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
## Summary

- `MatchAnnouncementTemplate`, `MatchResultOfficialTemplate`, `MatchResultFriendlyTemplate`: 팀명에 `whiteSpace: nowrap` 추가하여 긴 팀명 줄바꿈 방지
- `MatchResultOfficialTemplate` GOALS 섹션: 득점자 행 정렬 `flex-end` → `center`, 선수명 폰트 크기·scaleX 조정

Closes #11

## Test plan

- [ ] 긴 팀명 입력 시 한 줄로 유지되는지 확인 (MATCH / RES-O / RES-F)
- [ ] RES-O GOALS 섹션 득점자 행 세로 정렬 확인